### PR TITLE
Correçao da decodificaçao de idade do SIM

### DIFF
--- a/pysus/preprocessing/decoders.py
+++ b/pysus/preprocessing/decoders.py
@@ -54,6 +54,8 @@ def decodifica_idade_SIM(idade, unidade="D"):
             idade = timedelta(days=int(idade[1:]) * 30).days
         elif idade.startswith('4'):
             idade = timedelta(days=int(idade[1:]) * 365).days
+        elif idade.startswith('5'):
+            idade = timedelta(days=int(idade[1:]) * 365).days + 10 * 365
         else:
             idade = np.nan
     except ValueError:


### PR DESCRIPTION
Faltava a codificação das idades acima de 100 anos, fazendo com que todas elas ficassem como NaN.