### PR TITLE
Correção do decoder de idade do SIM e testes

### DIFF
--- a/pysus/preprocessing/decoders.py
+++ b/pysus/preprocessing/decoders.py
@@ -97,7 +97,6 @@ def calculate_digit(geocode):
     dv = 0 if soma % 10 == 0 else (10 - (soma % 10))
     return dv
 
-@np.vectorize
 def add_dv(geocodigo):
     if len(str(geocodigo)) == 7:
         return geocodigo

--- a/pysus/preprocessing/decoders.py
+++ b/pysus/preprocessing/decoders.py
@@ -44,10 +44,15 @@ def decodifica_idade_SIM(idade, unidade="D"):
     :param unidade: Unidade de saida desejada: 'Y': anos, 'M' meses, 'D': dias, 'H': horas. Valor default: 'D'
     :return:
     """
-    fator = {'Y': 365., 'M': 30., 'D': 1., 'H': 1/24.}
+    fator = {'Y': 365., 'M': 30., 'D': 1., 'H': 1/24., 'm': 1/1440.}
+    less_than_days = False
     try:
-        if idade.startswith('1'):
-            idade = timedelta(hours=int(idade[1:])).days
+        if idade.startswith('0') and idade[1:] != '00':
+            idade = timedelta(minutes=int(idade[1:]))
+            less_than_days = True
+        elif idade.startswith('1'):
+            idade = timedelta(hours=int(idade[1:]))
+            less_than_days = True
         elif idade.startswith('2'):
             idade = timedelta(days=int(idade[1:])).days
         elif idade.startswith('3'):
@@ -60,6 +65,8 @@ def decodifica_idade_SIM(idade, unidade="D"):
             idade = np.nan
     except ValueError:
         idade = np.nan
+    if less_than_days:
+        idade = idade.seconds/86400 + idade.days
     return idade/fator.get(unidade, 1)
 
 
@@ -93,7 +100,7 @@ def calculate_digit(geocode):
     dv = 0 if soma % 10 == 0 else (10 - (soma % 10))
     return dv
 
-
+@np.vectorize
 def add_dv(geocodigo):
     if len(str(geocodigo)) == 7:
         return geocodigo

--- a/pysus/preprocessing/decoders.py
+++ b/pysus/preprocessing/decoders.py
@@ -45,14 +45,13 @@ def decodifica_idade_SIM(idade, unidade="D"):
     :return:
     """
     fator = {'Y': 365., 'M': 30., 'D': 1., 'H': 1/24., 'm': 1/1440.}
-    less_than_days = False
     try:
         if idade.startswith('0') and idade[1:] != '00':
             idade = timedelta(minutes=int(idade[1:]))
-            less_than_days = True
+            idade = idade.seconds/86400 + idade.days
         elif idade.startswith('1'):
             idade = timedelta(hours=int(idade[1:]))
-            less_than_days = True
+            idade = idade.seconds/86400 + idade.days
         elif idade.startswith('2'):
             idade = timedelta(days=int(idade[1:])).days
         elif idade.startswith('3'):
@@ -65,8 +64,6 @@ def decodifica_idade_SIM(idade, unidade="D"):
             idade = np.nan
     except ValueError:
         idade = np.nan
-    if less_than_days:
-        idade = idade.seconds/86400 + idade.days
     return idade/fator.get(unidade, 1)
 
 

--- a/pysus/preprocessing/decoders.py
+++ b/pysus/preprocessing/decoders.py
@@ -55,7 +55,7 @@ def decodifica_idade_SIM(idade, unidade="D"):
         elif idade.startswith('4'):
             idade = timedelta(days=int(idade[1:]) * 365).days
         elif idade.startswith('5'):
-            idade = timedelta(days=int(idade[1:]) * 365).days + 10 * 365
+            idade = timedelta(days=int(idade[1:]) * 365).days + 100 * 365
         else:
             idade = np.nan
     except ValueError:

--- a/pysus/tests/test_decoders.py
+++ b/pysus/tests/test_decoders.py
@@ -34,5 +34,17 @@ class TestDecoder(unittest.TestCase):
         res = decoders.decodifica_idade_SINAN([1480] * 5, unidade='Y')
         assert_array_almost_equal(res, np.array([0.0547] * 5), decimal=3)
 
+    def test_decodifica_idade_retorna_em_anos_SIM(self):
+        res = decoders.decodifica_idade_SIM(['501'], unidade='Y')
+        assert_array_equal(res, np.array([101]))
+        res = decoders.decodifica_idade_SIM(['401'] * 2, unidade='Y')
+        assert_array_equal(res, np.array([1] * 2))
+        res = decoders.decodifica_idade_SIM(['311'] * 3, unidade='Y')
+        assert_array_almost_equal(res, np.array([0.904109589] * 3), decimal=3)
+        res = decoders.decodifica_idade_SIM(['224'] * 4, unidade='Y')
+        assert_array_almost_equal(res, np.array([0.065753425]*4), decimal=3)
+        res = decoders.decodifica_idade_SIM(['130'] * 5, unidade='Y')
+        assert_array_almost_equal(res, np.array([0.00274] * 5), decimal=3)
+
     def test_verifica_geocodigo(self):
         self.assertTrue(decoders.is_valid_geocode(3304557))

--- a/pysus/tests/test_decoders.py
+++ b/pysus/tests/test_decoders.py
@@ -45,6 +45,8 @@ class TestDecoder(unittest.TestCase):
         assert_array_almost_equal(res, np.array([0.065753425]*4), decimal=3)
         res = decoders.decodifica_idade_SIM(['130'] * 5, unidade='Y')
         assert_array_almost_equal(res, np.array([0.00274] * 5), decimal=3)
+        res = decoders.decodifica_idade_SIM(['010'] * 6, unidade='m')
+        assert_array_almost_equal(res, np.array([10.] * 6))
 
     def test_verifica_geocodigo(self):
         self.assertTrue(decoders.is_valid_geocode(3304557))


### PR DESCRIPTION
Eu tinha esquecido de digitar um 0 na função... Aproveitei e adicionei testes para a função mas acho que ela ainda tem erros, principalmente decodificando idade em minutos e horas. Vou dar uma olhada melhor essa semana.