### PR TITLE
Support for downloading custom SIASUS files

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,3 +161,28 @@ Out[3]:
 4     2009       07        16505851000126  ...                    2126796     1
 [5 rows x 27 columns]
 ```
+
+Dowloading and reading SIA data:
+
+```python
+In[1]: from pysus.online_data.SIA import download
+In[2]: bi, ps = download('AC', 2020, 3, group=["BI", "PS"])
+In[3]: bi.head()
+Out[3]: 
+    CODUNI  GESTAO CONDIC   UFMUN TPUPS  ... VL_APROV UFDIF MNDIF ETNIA NAT_JUR
+0  2000733  120000     EP  120040    07  ...     24.2     0     0          1023
+1  2001063  120000     EP  120040    36  ...      7.3     0     0          1023
+2  2001063  120000     EP  120040    36  ...      7.3     0     0          1023
+3  2001586  120000     EP  120040    05  ...     38.1     0     0          1147
+4  2000083  120000     EP  120033    05  ...     64.8     0     0          1023
+[5 rows x 36 columns]
+In[4]: ps.head()
+Out[4]:
+  CNES_EXEC  GESTAO CONDIC   UFMUN  ... PERMANEN QTDATE QTDPCN NAT_JUR
+0   2002094  120000     EP  120040  ...       30      1      1    1023
+1   2002094  120000     EP  120040  ...               0      0    1023
+2   2002094  120000     EP  120040  ...               0      0    1023
+3   2002094  120000     EP  120040  ...               0      0    1023
+4   2002094  120000     EP  120040  ...               0      0    1023
+[5 rows x 45 columns]
+```

--- a/pysus/online_data/SIA.py
+++ b/pysus/online_data/SIA.py
@@ -84,7 +84,7 @@ def download(
         gname = gname.upper()
         if gname not in group_dict:
             raise ValueError(
-                'SIA does not contain files named {}'.format(gname)
+                f'SIA does not contain files named {gname}'
             )
 
         # Check available
@@ -96,12 +96,12 @@ def download(
             # backwards-compatibility with older behavior of returning
             # (PA, None) for calls after 1994 and before Jan, 2008
             raise Warning(
-                'SIA does not contain data for {} before {:%d/%m/%Y}'
-                .format(gname, available_date)
+                f'SIA does not contain data for {gname} '
+                f'before {available_date:%d/%m/%Y}'
             )
             continue
 
-        fname = '{}{}{}{}.dbc'.format(gname, state, year2.zfill(2), month)
+        fname = f'{gname}{state}{year2.zfill(2)}{month}.dbc'
 
         # Check in Cache
         cachefile = os.path.join(
@@ -134,14 +134,14 @@ def _fetch_file(fname, ftp, ftype):
     :param ftype: file type: DBF|DBC
     :return: pandas dataframe
     """
-    print("Downloading {}...".format(fname))
+    print(f'Downloading {fname}...')
     try:
-        ftp.retrbinary('RETR {}'.format(fname), open(fname, 'wb').write)
+        ftp.retrbinary(f'RETR {fname}', open(fname, 'wb').write)
     except:
         try:
-            ftp.retrbinary('RETR {}'.format(fname.lower()), open(fname, 'wb').write)
+            ftp.retrbinary(f'RETR {fname.lower()}', open(fname, 'wb').write)
         except:
-            raise Exception("File {} not available".format(fname))
+            raise Exception(f'File {fname} not available')
     if ftype == 'DBC':
         df = read_dbc(fname, encoding='iso-8859-1')
     elif ftype == 'DBF':

--- a/pysus/online_data/SIA.py
+++ b/pysus/online_data/SIA.py
@@ -2,67 +2,125 @@ u"""
 Downloads SIA data from Datasus FTP server
 Created on 21/09/18
 by fccoelho
+Modified on 18/04/21
+by bcbernardo
 license: GPL V3 or Later
 """
 
 import os
+from datetime import date
 from ftplib import FTP
+from typing import Dict, List, Optional, Tuple, Union
 from pysus.utilities.readdbc import read_dbc
 from dbfread import DBF
 import pandas as pd
 from pysus.online_data import CACHEPATH
 
+group_dict: Dict[str, Tuple[str, int, int]] = {
+    'PA': ('Produção Ambulatorial', 7, 1994),
+    'BI': ('Boletim de Produção Ambulatorial individualizado', 1, 2008),
+    'AD': ('APAC de Laudos Diversos', 1, 2008),
+    'AM': ('APAC de Medicamentos', 1, 2008),
+    'AN': ('APAC de Nefrologia', 1, 2008),
+    'AQ': ('APAC de Quimioterapia', 1, 2008),
+    'AR': ('APAC de Radioterapia', 1, 2008),
+    'AB': ('APAC de Cirurgia Bariátrica', 1, 2008),
+    'ACF': ('APAC de Confecção de Fístula', 1, 2008),
+    'ATD': ('APAC de Tratamento Dialítico', 1, 2008),
+    'AMP': ('APAC de Acompanhamento Multiprofissional', 1, 2008),
+    'SAD': ('RAAS de Atenção Domiciliar', 1, 2008),
+    'PS': ('RAAS Psicossocial', 1, 2008),
+}
 
-def download(state: str, year: int, month: int, cache: bool =True) -> object:
+
+def download(
+    state: str,
+    year: int,
+    month: int,
+    cache: bool = True,
+    group: Union[str, List[str]] = ['PA', 'BI'],
+) -> Tuple[Optional[pd.DataFrame], ...]:
     """
     Download SIH records for state year and month and returns dataframe
     :param month: 1 to 12
     :param state: 2 letter state code
     :param year: 4 digit integer
     :param cache: whether to cache files locally. default is True
-    :return: Two dataframes PA and BI
+    :param groups: 2 letter document code or a list of 2 letter codes, defaults
+        to ['PA', 'BI']. Codes should be one of the following:
+        PA - Produção Ambulatorial
+        BI - Boletim de Produção Ambulatorial individualizado
+        AD - APAC de Laudos Diversos
+        AM - APAC de Medicamentos
+        AN - APAC de Nefrologia
+        AQ - APAC de Quimioterapia
+        AR - APAC de Radioterapia
+        AB - APAC de Cirurgia Bariátrica
+        ACF - APAC de Confecção de Fístula
+        ATD - APAC de Tratamento Dialítico
+        AMP - APAC de Acompanhamento Multiprofissional
+        SAD - RAAS de Atenção Domiciliar
+        PS - RAAS Psicossocial
+    :return: A tuple of dataframes with the documents in the order given
+        by the , when they are found
     """
     state = state.upper()
     year2 = str(year)[-2:]
     month = str(month).zfill(2)
-    if year < 1992:
-        raise ValueError("SIH does not contain data before 1994")
+    if isinstance(group, str):
+        group = [group]
     ftp = FTP('ftp.datasus.gov.br')
     ftp.login()
-    if year < 2008 and year > 1994:
-        ftype = 'DBC'
+    ftype = 'DBC'
+    if year >= 1994 and year < 2008:
         ftp.cwd('/dissemin/publicos/SIASUS/199407_200712/Dados')
-        fname = 'PA{}{}{}.dbc'.format(state, year2, month)
-        fname2 = None
-    if year >= 2008:
-        ftype = 'DBC'
-        ftp.cwd('/dissemin/publicos/SIASUS/200801_/Dados'.format(year))
-        fname = 'PA{}{}{}.dbc'.format(state, str(year2).zfill(2), month)
-        fname2 = 'BI{}{}{}.dbc'.format(state, str(year2).zfill(2), month)
-    # Check in Cache
-    cachefile = os.path.join(CACHEPATH, 'SIA_' + fname.split('.')[0] + '_.parquet')
-    if os.path.exists(cachefile):
-        df = pd.read_parquet(cachefile)
+    elif year >= 2008:
+        ftp.cwd('/dissemin/publicos/SIASUS/200801_/Dados')
     else:
-        df = _fetch_file(fname, ftp, ftype)
-        if cache:
-            df.to_parquet(cachefile)
-    if fname2 is not None:
-        cachefile2 = os.path.join(CACHEPATH, 'SIA_' + fname2.split('.')[0] + '_.parquet')
-        if os.path.exists(cachefile2):  # reads from cache
-            df2 = pd.read_parquet(cachefile2)
-        else:  # fetches from DataSUS
-            try:
-                df2 = _fetch_file(fname2, ftp, ftype)
-                if cache:  #saves to cache
-                    df2.to_parquet(cachefile2)
-            except Exception as e:
-                df2 = None
-                print(e)
-    else:
-        df2 = None
+        raise ValueError('SIA does not contain data before 1994')
 
-    return df, df2
+    dfs: List[Optional[pd.DataFrame]] = list()
+    for gname in group:
+        gname = gname.upper()
+        if gname not in group_dict:
+            raise ValueError(
+                'SIA does not contain files named {}'.format(gname)
+            )
+
+        # Check available
+        input_date = date(int(year), int(month), 1)
+        available_date = date(group_dict[gname][2], group_dict[gname][1], 1)
+        if input_date < available_date:
+            dfs.append(None)
+            # NOTE: raise Warning instead of ValueError for
+            # backwards-compatibility with older behavior of returning
+            # (PA, None) for calls after 1994 and before Jan, 2008
+            raise Warning(
+                'SIA does not contain data for {} before {:%d/%m/%Y}'
+                .format(gname, available_date)
+            )
+            continue
+
+        fname = '{}{}{}{}.dbc'.format(gname, state, year2.zfill(2), month)
+
+        # Check in Cache
+        cachefile = os.path.join(
+            CACHEPATH, 'SIA_' + fname.split('.')[0] + '_.parquet'
+        )
+        if os.path.exists(cachefile):
+            df = pd.read_parquet(cachefile)
+        else:
+            try:
+                df = _fetch_file(fname, ftp, ftype)
+                if cache:  # saves to cache
+                    df.to_parquet(cachefile)
+            except Exception as e:
+                df = None
+                print(e)
+        
+        dfs.append(df)
+
+    return tuple(dfs)
 
 
 def _fetch_file(fname, ftp, ftype):
@@ -88,5 +146,3 @@ def _fetch_file(fname, ftp, ftype):
         df = pd.DataFrame(list(dbf))
     os.unlink(fname)
     return df
-
-

--- a/pysus/online_data/SIA.py
+++ b/pysus/online_data/SIA.py
@@ -41,13 +41,13 @@ def download(
     group: Union[str, List[str]] = ['PA', 'BI'],
 ) -> Union[Optional[pd.DataFrame], Tuple[Optional[pd.DataFrame], ...]]:
     """
-    Download SIH records for state year and month and returns dataframe
+    Download SIASUS records for state year and month and returns dataframe
     :param month: 1 to 12
     :param state: 2 letter state code
     :param year: 4 digit integer
     :param cache: whether to cache files locally. default is True
-    :param groups: 2 letter document code or a list of 2 letter codes, defaults
-        to ['PA', 'BI']. Codes should be one of the following:
+    :param groups: 2-3 letter document code or a list of 2-3 letter codes,
+        defaults to ['PA', 'BI']. Codes should be one of the following:
         PA - Produção Ambulatorial
         BI - Boletim de Produção Ambulatorial individualizado
         AD - APAC de Laudos Diversos

--- a/pysus/online_data/SIA.py
+++ b/pysus/online_data/SIA.py
@@ -11,6 +11,8 @@ import os
 from datetime import date
 from ftplib import FTP
 from typing import Dict, List, Optional, Tuple, Union
+import warnings
+
 from pysus.utilities.readdbc import read_dbc
 from dbfread import DBF
 import pandas as pd
@@ -95,7 +97,7 @@ def download(
             # NOTE: raise Warning instead of ValueError for
             # backwards-compatibility with older behavior of returning
             # (PA, None) for calls after 1994 and before Jan, 2008
-            raise Warning(
+            warnings.warn(
                 f'SIA does not contain data for {gname} '
                 f'before {available_date:%d/%m/%Y}'
             )

--- a/pysus/online_data/SIA.py
+++ b/pysus/online_data/SIA.py
@@ -39,7 +39,7 @@ def download(
     month: int,
     cache: bool = True,
     group: Union[str, List[str]] = ['PA', 'BI'],
-) -> Tuple[Optional[pd.DataFrame], ...]:
+) -> Union[Optional[pd.DataFrame], Tuple[Optional[pd.DataFrame], ...]]:
     """
     Download SIH records for state year and month and returns dataframe
     :param month: 1 to 12
@@ -117,10 +117,13 @@ def download(
             except Exception as e:
                 df = None
                 print(e)
-        
+
         dfs.append(df)
 
-    return tuple(dfs)
+    if len(dfs) == 1:
+        return dfs[0]
+    else:
+        return tuple(dfs)
 
 
 def _fetch_file(fname, ftp, ftype):

--- a/pysus/tests/test_data/test_sia.py
+++ b/pysus/tests/test_data/test_sia.py
@@ -5,6 +5,8 @@ from pysus.online_data.SIA import download
 import pandas as pd
 
 unittest.skip("too slow to run om travis")
+
+
 class SIATestCase(unittest.TestCase):
     def test_download_after_2008(self):
         df, df2 = download('to', 2009, 12)
@@ -16,9 +18,40 @@ class SIATestCase(unittest.TestCase):
 
     def test_download_before_2008(self):
         df, _ = download('mg', 2006, 10)
+        self.assertWarns(UserWarning)
         self.assertGreater(len(df), 0)
         self.assertIn('PA_CODUNI', df.columns)
         self.assertIsInstance(df, pd.DataFrame)
+
+    @unittest.expectedFailure
+    def test_download_before_1994(self):
+        df1, df2 = download('RS', 1993, 12)
+
+    def test_download_one(self):
+        df = download('se', 2020, 10, group="PS")
+        self.assertGreater(len(df), 0)
+        self.assertIn('CNS_PAC', df.columns)
+        self.assertIsInstance(df, pd.DataFrame)
+
+    def test_download_many(self):
+        df1, df2, df3 = download('PI', 2018, 3, group=["aq", "AM", "atd"])
+        self.assertIsInstance(df1, pd.DataFrame)
+        self.assertIsInstance(df2, pd.DataFrame)
+        self.assertIsInstance(df2, pd.DataFrame)
+        self.assertGreater(len(df1), 0)
+        self.assertGreater(len(df2), 0)
+        self.assertGreater(len(df3), 0)
+        self.assertIn('AP_CODUNI', df1.columns)
+        self.assertIn('AP_CODUNI', df2.columns)
+        self.assertIn('AP_CODUNI', df3.columns)
+        self.assertIn('AQ_CID10', df1.columns)
+        self.assertIn('AM_PESO', df2.columns)
+        self.assertIn('ATD_CARACT', df3.columns)
+
+    def test_download_missing(self):
+        df1, df2 = download('MS', 2006, 5, group=["PA", "SAD"])
+        self.assertIsInstance(df1, pd.DataFrame)
+        self.assertIsNone(df2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR implements the enhancements proposed in #15, regarding to downloads from SIASUS other than the "Produção Ambulatorial" (PA) and "Boletim de Produção Ambulatorial individualizado" (BI) files.

Some notes on the implementation:

- The document types to be downloaded are specified with the `group` parameter in the `pysus.online_data.SIA.download()` function, which tries to mimic the interface proposed in PR #31 for CNES files. However, this implementation supports this parameter being provided both as a single string (for a single type of document) or an iterable of document type codes (which are returned in the provided order).
- The defaults for the mentioned `group` and its position amongst other function arguments are intended to provide backwards-compatibility with previous implementation, so that a function call without the `group` parameter still returns a (PA, BI) tuple.
- Downloading from SIASUS is documented in README,md.