### PR TITLE
Modified ESUS download to use constant memory

### DIFF
--- a/docs/source/ESUS.ipynb
+++ b/docs/source/ESUS.ipynb
@@ -23,7 +23,7 @@
    "metadata": {},
    "source": [
     "# Downloading data from ESUS\n",
-    "This function alows for the download of COVID-19 data from ESUS."
+    "This function alows for the download of COVID-19 data from ESUS. For Some States, the size of the resulting table can easily exceed the memory size of most personal computers, in such cases, the ESUS download function will stream the data to disk without filling up the memory and return an iterator of chunks of 1000 rows of data. The user must then iterate over the chunks to analyze the data."
    ]
   },
   {

--- a/pysus/online_data/ESUS.py
+++ b/pysus/online_data/ESUS.py
@@ -1,4 +1,5 @@
 import pandas as pd
+import dask.dataframe as dd
 from pysus.online_data import CACHEPATH
 from elasticsearch import Elasticsearch
 import elasticsearch.helpers
@@ -6,12 +7,12 @@ import os
 import time
 from datetime import date
 
-def download(uf, cache=True):
+def download(uf, cache=True, checkmemory=True):
     """
     Download ESUS data by UF
     :param uf: rj, mg, etc
     :param cache: if results should be cached on disk
-    :return:
+    :return: DataFrame if data fits in memory, other an iterator of chunks of size 1000.
     """
     uf = uf.lower()
     user = 'user-public-notificacoes'
@@ -22,24 +23,67 @@ def download(uf, cache=True):
     url = f'https://{user}:{pwd}@elasticsearch-saps.saude.gov.br'
     out = f'ESUS_{uf}_{dt}.parquet'
 
-    cachefile = os.path.join(CACHEPATH, 'ESUS_' + out)
+    cachefile = os.path.join(CACHEPATH, out)
+    tempfile = os.path.join(CACHEPATH, f'ESUS_temp_{UF}.csv.gz')
     if os.path.exists(cachefile):
         df = pd.read_parquet(cachefile)
+    elif os.path.exists(tempfile):
+        df = pd.read_csv(tempfile, chunksize=1000)
     else:
-        df = fetch(base, uf, url)
-        if cache:
-            df.to_parquet(cachefile)
+        fname = fetch(base, uf, url)
+        size = os.stat(fname).st_size
+        if size > 50e6 and checkmemory:
+            print(f"Downloaded data is to large:{size/1e6} MB compressed.")
+            print("Only loading the first 1000 rows. If your computer has enough memory, set 'checkmemory' to False")
+            print(f"The full data is in {fname}")
+            df = pd.read_csv(fname, chunksize=1000)
+        else:
+            df = pd.read_csv(fname)
+            print(f"{df.shape[0]} records downloaded.")
+            os.unlink(fname)
+            if cache:
+                df.to_parquet(cachefile)
 
     return df
 
 
 
 def fetch(base, uf, url):
-    print(f"Reading ESUS data for {uf.upper()}")
+    UF = uf.upper()
+    print(f"Reading ESUS data for {UF}")
     es = Elasticsearch([url], send_get_body_as='POST')
     body = {"query": {"match_all": {}}}
     results = elasticsearch.helpers.scan(es, query=body, index=base)
-    df = pd.DataFrame.from_dict([document['_source'] for document in results])
-    print(f"{df.shape[0]} records downloaded.")
-    df.sintomas = df['sintomas'].str.replace(';', '', )  ## remove os  ;
-    return df
+    # df = pd.DataFrame.from_dict([document['_source'] for document in results])
+
+    chunker = chunky_fetch(results, 3000)
+    h = 1
+    tempfile = os.path.join(CACHEPATH, f'ESUS_temp_{UF}.csv.gz')
+    for ch in chunker:
+        df = pd.DataFrame.from_dict(ch)
+        df.sintomas = df['sintomas'].str.replace(';', '',)  ## remove os  ;
+        if h:
+            df.to_csv(tempfile)
+            h = 0
+        else:
+            df.to_csv(tempfile, mode='a', header=False)
+    # df = pd.read_csv('temp.csv.gz')
+
+
+
+    return tempfile
+
+
+def chunky_fetch(results, chunk_size=3000):
+    "Fetches data in chunks to preserve memory"
+    data = []
+    i = 0
+    for d in results:
+        data.append(d['_source'])
+        i += 1
+        if i == chunk_size:
+            yield data
+            data = []
+            i = 0
+    else:
+        return data

--- a/pysus/preprocessing/ESUS.py
+++ b/pysus/preprocessing/ESUS.py
@@ -1,0 +1,55 @@
+from pysus.online_data.ESUS import download
+import numpy as np
+import pandas as pd
+
+
+def cases_by_age_and_sex(UF):
+    """
+    Fetches ESUS covid line list and aggregates by age and sex returning these counts.
+    :param UF: State code
+    :return: dataframe
+    """
+    df = download(uf=UF)
+
+    # Transformando as colunas em datetime type
+    for cname in df:
+        if cname.startswith('data'):
+            df[cname] = pd.to_datetime(df[cname], errors='coerce')
+
+    # Eliminando os valores nulos nas colunas com datas importantes
+    old_size = len(df)
+    df.dropna(subset = ['dataNotificacao', 'dataInicioSintomas', 'dataTeste'], inplace = True)
+    print(f"Removed {old_size-len(df)} rows with missing dates of symptoms, notification or testing")
+
+
+    # Desconsiderando os resultados negativos ou inconclusivos
+    df = df.loc[~df.resultadoTeste.isin(['Negativo','Inconclusivo ou Indeterminado'])]
+
+    # Removendo sexo indeterminado
+    df = df.loc[df.sexo.isin(['Masculino','Feminino'])]
+
+    # determinando a data dos primeiros sintomas como a data do index
+
+    df['datesint'] = df['dataInicioSintomas']
+    df.set_index('datesint', inplace=True);
+    df.sort_index(inplace=True, ascending=True)
+
+    # vamos limitar a data inicial e a data final considerando apenas a primeira onda
+
+    d1 = '2020-03-01'
+    d2 = '2020-08-31'
+
+    df = df.loc[d1:d2]
+
+    ini = np.arange(0,81,5)
+    fin = np.arange(5,86, 5)
+    fin[-1]=120
+    faixa_etaria = {f'[{i},{f})':(i,f) for i,f in zip(ini,fin)}
+
+    labels = list(faixa_etaria.keys())
+    df['faixa_etaria'] = [labels[i-1] for i in np.digitize(df.idade,bins=ini)]
+
+    agreg = df[['sexo', 'faixa_etaria']].groupby(['faixa_etaria', 'sexo']).size()
+    agreg = agreg.reset_index()
+    agreg.columns=['faixa_etaria', 'sexo','n']
+    return agreg

--- a/setup.py
+++ b/setup.py
@@ -17,10 +17,11 @@ Features
 
 - Decode encoded patient age to any time unit (years, months, etc)
 - Convert `.dbc` files to DBF databases or read them into pandas dataframes. DBC files are basically DBFs compressed by a proprietary algorithm.
-- Loads SINAN files into Pandas Dataframes
+- Loads SINAN DBC files into Pandas Dataframes
+- Downloads SIA, SIH, SIM, SINASC, and ESUS (covid data) 
 - Geocodes SINAN notified cases in batch. You can use your Google API KEY to avoid Google's free limits.
 
-Instalation
+Installation
 -----------
 Make sure your system has libffi-dev package installed,
 
@@ -80,7 +81,7 @@ Make sure your system has libffi-dev package installed,
 # atexit.register(_post_install)
 setup(
     name='PySUS',
-    version='0.5.4',
+    version='0.5.5',
     packages=find_packages(),
     package_data={
         '': ['*.c', '*.h', '*.o', '*.so', '*.md', '*.txt']
@@ -95,7 +96,7 @@ setup(
     long_description=ld,
     setup_requires=['cffi>=1.0.0', 'setuptools>26.0.0'],
     cffi_modules=["pysus/utilities/_build_readdbc.py:ffibuilder"],
-    install_requires=['pandas', 'dbfread', 'cffi>=1.0.0', 'geocoder', 'requests', 'pyarrow', 'fastparquet'],
+    install_requires=['pandas', 'dbfread', 'cffi>=1.0.0', 'geocoder', 'requests', 'fastparquet'],
     # cmdclass={'install': PostInstall},
 )
 


### PR DESCRIPTION
This PR allows for the download of ESUS case data from large states such as RJ and SP which are too big to fit in the memory of most personal computers.  It does it by streaming the download to disk, and returning a dataframe iterator in chunks of 1000
Added case counter by age and sex of ESUS data