### PR TITLE
Logging online_data modules for a better track of methods

### DIFF
--- a/conda/dev.yaml
+++ b/conda/dev.yaml
@@ -8,7 +8,6 @@ dependencies:
   - gcc
   - make
   - pip
-  - poetry
   - psycopg2
   - python 3.9.*
   - poetry

--- a/conda/dev.yaml
+++ b/conda/dev.yaml
@@ -8,6 +8,7 @@ dependencies:
   - gcc
   - make
   - pip
+  - poetry
   - psycopg2
   - python 3.9.*
   - poetry

--- a/poetry.lock
+++ b/poetry.lock
@@ -743,6 +743,21 @@ openapi = ["openapi-core (>=0.14.2)", "ruamel-yaml"]
 test = ["codecov", "ipykernel", "jupyter-server", "openapi-core (>=0.14.2,<0.15.0)", "openapi-spec-validator (<0.5)", "pytest (>=7.0)", "pytest-console-scripts", "pytest-cov", "requests-mock", "ruamel-yaml", "strict-rfc3339"]
 
 [[package]]
+name = "loguru"
+version = "0.6.0"
+description = "Python logging made (stupidly) simple"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.dependencies]
+colorama = {version = ">=0.3.4", markers = "sys_platform == \"win32\""}
+win32-setctime = {version = ">=1.0.0", markers = "sys_platform == \"win32\""}
+
+[package.extras]
+dev = ["Sphinx (>=4.1.1)", "black (>=19.10b0)", "colorama (>=0.3.4)", "docutils (==0.16)", "flake8 (>=3.7.7)", "isort (>=5.1.1)", "pytest (>=4.6.2)", "pytest-cov (>=2.7.1)", "sphinx-autobuild (>=0.7.1)", "sphinx-rtd-theme (>=0.4.3)", "tox (>=3.9.0)"]
+
+[[package]]
 name = "markupsafe"
 version = "2.1.1"
 description = "Safely add untrusted strings to HTML/XML markup."
@@ -1652,6 +1667,17 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "win32-setctime"
+version = "1.1.0"
+description = "A small Python utility to set file creation time on Windows"
+category = "main"
+optional = false
+python-versions = ">=3.5"
+
+[package.extras]
+dev = ["black (>=19.3b0)", "pytest (>=4.6.2)"]
+
+[[package]]
 name = "zipp"
 version = "3.10.0"
 description = "Backport of pathlib-compatible object wrapper for zip files"
@@ -1666,7 +1692,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.9"
-content-hash = "74bf633745d9d1dd29ac677b0fb68394cad778c3b0bd72a59e97c4f1c06d7da0"
+content-hash = "ed1c3e8528b31befa219d674b48cb8010701055ed33b5f0e11d19cc2213826fa"
 
 [metadata.files]
 alabaster = [
@@ -2082,6 +2108,10 @@ jupyterlab-pygments = [
 jupyterlab-server = [
     {file = "jupyterlab_server-2.16.3-py3-none-any.whl", hash = "sha256:d18eb623428b4ee732c2258afaa365eedd70f38b609981ea040027914df32bc6"},
     {file = "jupyterlab_server-2.16.3.tar.gz", hash = "sha256:635a0b176a901f19351c02221a124e59317c476f511200409b7d867e8b2905c3"},
+]
+loguru = [
+    {file = "loguru-0.6.0-py3-none-any.whl", hash = "sha256:4e2414d534a2ab57573365b3e6d0234dfb1d84b68b7f3b948e6fb743860a77c3"},
+    {file = "loguru-0.6.0.tar.gz", hash = "sha256:066bd06758d0a513e9836fd9c6b5a75bfb3fd36841f4b996bc60b547a309d41c"},
 ]
 markupsafe = [
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
@@ -2655,6 +2685,10 @@ websocket-client = [
 ]
 wget = [
     {file = "wget-3.2.zip", hash = "sha256:35e630eca2aa50ce998b9b1a127bb26b30dfee573702782aa982f875e3f16061"},
+]
+win32-setctime = [
+    {file = "win32_setctime-1.1.0-py3-none-any.whl", hash = "sha256:231db239e959c2fe7eb1d7dc129f11172354f98361c4fa2d6d2d7e278baa8aad"},
+    {file = "win32_setctime-1.1.0.tar.gz", hash = "sha256:15cf5750465118d6929ae4de4eb46e8edae9a5634350c01ba582df868e932cb2"},
 ]
 zipp = [
     {file = "zipp-3.10.0-py3-none-any.whl", hash = "sha256:4fcb6f278987a6605757302a6e40e896257570d11c51628968ccb2a47e80c6c1"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysus"
-version = "0.6.2"
+version = "0.6.3"
 description = "Tools for dealing with Brazil's Public health data"
 authors = ["Flavio Codeco Coelho <fccoelho@gmail.com>"]
 license = "GPL"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ pytz = "2022.2.1"
 six = "1.16.0"
 tqdm = "4.64.0"
 wget = "^3.2"
+loguru = "^0.6.0"
 
 [tool.poetry.dev-dependencies]
 black = "^22.6.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysus"
-version = "0.6.1"
+version = "0.6.2"
 description = "Tools for dealing with Brazil's Public health data"
 authors = ["Flavio Codeco Coelho <fccoelho@gmail.com>"]
 license = "GPL"

--- a/pysus/online_data/CIHA.py
+++ b/pysus/online_data/CIHA.py
@@ -37,11 +37,13 @@ def download(state: str, year: int, month: int, cache: bool = True) -> object:
     if year > 2008 and year < 2011:
         ftype = "DBC"
         ftp.cwd("/dissemin/publicos/CIH/200801_201012/Dados")
+        logger.debug("Changing FTP work dir to: /dissemin/publicos/CIH/200801_201012/Dados")
         fname = "CR{}{}{}.dbc".format(state, year2, month)
 
     if year >= 2011:
         ftype = "DBC"
         ftp.cwd("/dissemin/publicos/CIHA/201101_/Dados")
+        logger.debug("Changing FTP work dir to: /dissemin/publicos/CIHA/201101_/Dados")
         fname = "CIHA{}{}{}.dbc".format(state, str(year2).zfill(2), month)
         
     cachefile = os.path.join(CACHEPATH, "CIHA_" + fname.split(".")[0] + "_.parquet")

--- a/pysus/online_data/CIHA.py
+++ b/pysus/online_data/CIHA.py
@@ -54,7 +54,7 @@ def download(state: str, year: int, month: int, cache: bool = True) -> object:
     df = _fetch_file(fname, ftp, ftype)
 
     if cache:
-        logger.debug(f"Data stored as parquet at {cachefile}")
+        logger.info(f"Data stored as parquet at {cachefile}")
         df.to_parquet(cachefile)
     return df
 

--- a/pysus/online_data/CIHA.py
+++ b/pysus/online_data/CIHA.py
@@ -47,15 +47,15 @@ def download(state: str, year: int, month: int, cache: bool = True) -> object:
     cachefile = os.path.join(CACHEPATH, "CIHA_" + fname.split(".")[0] + "_.parquet")
 
     if os.path.exists(cachefile):
-        logger.debug(f"Data cache found as parquet at {cachefile}")
+        logger.info(f"Local parquet data found at {cachefile}")
         df = pd.read_parquet(cachefile)
         return df
 
     df = _fetch_file(fname, ftp, ftype)
 
     if cache:
-        logger.info(f"Data stored as parquet at {cachefile}")
         df.to_parquet(cachefile)
+        logger.info(f"Data stored as parquet at {cachefile}")
     return df
 
 

--- a/pysus/online_data/CIHA.py
+++ b/pysus/online_data/CIHA.py
@@ -9,11 +9,11 @@ license: GPL V3 or Later
 """
 
 import os
-from ftplib import FTP, error_perm
-
 import pandas as pd
-from dbfread import DBF
 
+from dbfread import DBF
+from loguru import logger
+from ftplib import FTP, error_perm
 from pysus.online_data import CACHEPATH
 from pysus.utilities.readdbc import read_dbc
 
@@ -32,20 +32,29 @@ def download(state: str, year: int, month: int, cache: bool = True) -> object:
         raise ValueError("CIHA does not contain data before 2008")
     ftp = FTP("ftp.datasus.gov.br")
     ftp.login()
+    logger.debug(f"Stablishing connection.\n{ftp.welcome}")
+
     if year > 2008 and year < 2011:
         ftype = "DBC"
         ftp.cwd("/dissemin/publicos/CIH/200801_201012/Dados")
         fname = "CR{}{}{}.dbc".format(state, year2, month)
+
     if year >= 2011:
         ftype = "DBC"
         ftp.cwd("/dissemin/publicos/CIHA/201101_/Dados")
         fname = "CIHA{}{}{}.dbc".format(state, str(year2).zfill(2), month)
+        
     cachefile = os.path.join(CACHEPATH, "CIHA_" + fname.split(".")[0] + "_.parquet")
+
     if os.path.exists(cachefile):
+        logger.debug(f"Data cache found as parquet at {cachefile}")
         df = pd.read_parquet(cachefile)
         return df
+
     df = _fetch_file(fname, ftp, ftype)
+
     if cache:
+        logger.debug(f"Data stored as parquet at {cachefile}")
         df.to_parquet(cachefile)
     return df
 

--- a/pysus/online_data/CIHA.py
+++ b/pysus/online_data/CIHA.py
@@ -32,7 +32,7 @@ def download(state: str, year: int, month: int, cache: bool = True) -> object:
         raise ValueError("CIHA does not contain data before 2008")
     ftp = FTP("ftp.datasus.gov.br")
     ftp.login()
-    logger.debug(f"Stablishing connection.\n{ftp.welcome}")
+    logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
 
     if year > 2008 and year < 2011:
         ftype = "DBC"

--- a/pysus/online_data/CNES.py
+++ b/pysus/online_data/CNES.py
@@ -78,7 +78,7 @@ def download(
     df = _fetch_file(fname, ftp, ftype)
 
     if cache:
-        logger.debug(f"Data stored as parquet at {cachefile}")
+        logger.info(f"Data stored as parquet at {cachefile}")
         df.to_parquet(cachefile)
 
     return df

--- a/pysus/online_data/CNES.py
+++ b/pysus/online_data/CNES.py
@@ -1,9 +1,10 @@
 import os
+import pandas as pd
+
+from dbfread import DBF
+from loguru import logger
 from datetime import datetime
 from ftplib import FTP, error_perm
-
-import pandas as pd
-from dbfread import DBF
 
 from pysus.online_data import CACHEPATH
 from pysus.utilities.readdbc import read_dbc
@@ -54,21 +55,32 @@ def download(
     month = str(month).zfill(2)
     input_date = datetime(int(year), int(month), 1)
     avaiable_date = datetime(group_dict[group][2], group_dict[group][1], 1)
+
     if input_date < avaiable_date:
         raise ValueError(f"CNES does not contain data for {input_date}")
+
     ftp = FTP("ftp.datasus.gov.br")
     ftp.login()
+    logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
+
     if input_date >= avaiable_date:
         ftype = "DBC"
         ftp.cwd("dissemin/publicos/CNES/200508_/Dados/{}/".format(group))
         fname = "{}{}{}{}.dbc".format(group, state, str(year2).zfill(2), month)
+
     cachefile = os.path.join(CACHEPATH, "CNES_" + fname.split(".")[0] + "_.parquet")
+
     if os.path.exists(cachefile):
+        logger.info(f"Using local data: {cachefile}")
         df = pd.read_parquet(cachefile)
         return df
+
     df = _fetch_file(fname, ftp, ftype)
+
     if cache:
+        logger.debug(f"Data stored as parquet at {cachefile}")
         df.to_parquet(cachefile)
+
     return df
 
 
@@ -83,4 +95,5 @@ def _fetch_file(fname: str, ftp: FTP, ftype: str) -> pd.DataFrame:
         dbf = DBF(fname, encoding="iso-8859-1")
         df = pd.DataFrame(list(dbf))
     os.unlink(fname)
+    logger.debug(f"{fname} removed.")
     return df

--- a/pysus/online_data/CNES.py
+++ b/pysus/online_data/CNES.py
@@ -66,6 +66,7 @@ def download(
     if input_date >= avaiable_date:
         ftype = "DBC"
         ftp.cwd("dissemin/publicos/CNES/200508_/Dados/{}/".format(group))
+        logger.debug("Changing FTP work dir to: dissemin/publicos/CNES/200508_/Dados/{}/".format(group))
         fname = "{}{}{}{}.dbc".format(group, state, str(year2).zfill(2), month)
 
     cachefile = os.path.join(CACHEPATH, "CNES_" + fname.split(".")[0] + "_.parquet")

--- a/pysus/online_data/CNES.py
+++ b/pysus/online_data/CNES.py
@@ -71,15 +71,15 @@ def download(
     cachefile = os.path.join(CACHEPATH, "CNES_" + fname.split(".")[0] + "_.parquet")
 
     if os.path.exists(cachefile):
-        logger.info(f"Using local data: {cachefile}")
+        logger.info(f"Local parquet data found at {cachefile}")
         df = pd.read_parquet(cachefile)
         return df
 
     df = _fetch_file(fname, ftp, ftype)
 
     if cache:
-        logger.info(f"Data stored as parquet at {cachefile}")
         df.to_parquet(cachefile)
+        logger.info(f"Data stored as parquet at {cachefile}")
 
     return df
 

--- a/pysus/online_data/ESUS.py
+++ b/pysus/online_data/ESUS.py
@@ -27,10 +27,10 @@ def download(uf, cache=True, checkmemory=True):
     cachefile = os.path.join(CACHEPATH, out)
     tempfile = os.path.join(CACHEPATH, f"ESUS_temp_{uf.upper()}.csv.gz")
     if os.path.exists(cachefile):
-        logger.info(f"Using local parquet file: {cachefile}")
+        logger.info(f"Local parquet file found at {cachefile}")
         df = pd.read_parquet(cachefile)
     elif os.path.exists(tempfile):
-        logger.info(f"Using local csv file: {tempfile}")
+        logger.info(f"Local csv file found at {tempfile}")
         df = pd.read_csv(tempfile, chunksize=1000)
     else:
         fname = fetch(base, uf, url)

--- a/pysus/online_data/IBGE.py
+++ b/pysus/online_data/IBGE.py
@@ -1,15 +1,13 @@
 """
 Helper functions to download official statistics from IBGE SIDRA
 """
-import json
-from urllib.error import HTTPError
 
-import pandas as pd
-import requests
 import urllib3
-import io
+import requests
+import pandas as pd
 # requests.packages.urllib3.util.ssl_.DEFAULT_CIPHERS = 'ALL:@SECLEVEL=1'
 
+from urllib.error import HTTPError
 
 APIBASE = "https://servicodados.ibge.gov.br/api/v3/"
 

--- a/pysus/online_data/PNI.py
+++ b/pysus/online_data/PNI.py
@@ -27,6 +27,7 @@ def download(state, year, cache=True):
     ftp.login()
     logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
     ftp.cwd("/dissemin/publicos/PNI/DADOS")
+    logger.debug("Changing FTP work dir to: /dissemin/publicos/PNI/DADOS")
     fname = f"CPNI{state}{year2}.DBF"
 
     cachefile = os.path.join(CACHEPATH, "PNI_" + fname.split(".")[0] + "_.parquet")
@@ -62,6 +63,7 @@ def get_available_years(state):
     ftp.login()
     logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
     ftp.cwd("/dissemin/publicos/PNI/DADOS")
+    logger.debug("Changing FTP work dir to: /dissemin/publicos/PNI/DADOS")
     res = ftp.nlst(f"CPNI{state}*.DBF")
     return res
 
@@ -71,6 +73,7 @@ def available_docs():
     ftp.login()
     logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
     ftp.cwd("/dissemin/publicos/PNI/DOCS")
+    logger.debug("Changing FTP work dir to: /dissemin/publicos/PNI/DOCS")
     res = ftp.nlst(f"*")
     return res
 
@@ -80,6 +83,7 @@ def fetch_document(fname):
     ftp.login()
     logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
     ftp.cwd("/dissemin/publicos/PNI/DOCS")
+    logger.debug("Changing FTP work dir to: /dissemin/publicos/PNI/DOCS")
     try:
         ftp.retrbinary("RETR {}".format(fname), open(fname, "wb").write)
         print(f"Downloaded {fname}.")

--- a/pysus/online_data/SIA.py
+++ b/pysus/online_data/SIA.py
@@ -85,7 +85,7 @@ def download(
     elif year >= 2008:
         ftp.cwd("/dissemin/publicos/SIASUS/200801_/Dados")
         logger.debug("Changing FTP work dir to: /dissemin/publicos/SIASUS/200801_/Dados")
-        
+
     else:
         raise ValueError("SIA does not contain data before 1994")
 
@@ -103,7 +103,7 @@ def download(
             # NOTE: raise Warning instead of ValueError for
             # backwards-compatibility with older behavior of returning
             # (PA, None) for calls after 1994 and before Jan, 2008
-            logger.warn(
+            logger.warning(
                 f"SIA does not contain data for {gname} "
                 f"before {available_date:%d/%m/%Y}"
             )

--- a/pysus/online_data/SIA.py
+++ b/pysus/online_data/SIA.py
@@ -18,7 +18,7 @@ from pprint import pprint
 from typing import Dict, List, Optional, Tuple, Union
 
 from pysus.online_data import CACHEPATH
-from pysus.utilities.readdbc import read_dbc, read_dbc_dbf, dbc2dbf
+from pysus.utilities.readdbc import read_dbc_dbf, dbc2dbf
 
 group_dict: Dict[str, Tuple[str, int, int]] = {
     "PA": ("Produção Ambulatorial", 7, 1994),
@@ -152,6 +152,7 @@ def _fetch_file(fname, ftp, ftype):
 
     os.unlink(fname)
     logger.debug(f"{fname} removed")
+    
     return df
 
 

--- a/pysus/online_data/SIA.py
+++ b/pysus/online_data/SIA.py
@@ -11,7 +11,6 @@ import os
 import pandas as pd
 
 from ftplib import FTP
-from dbfread import DBF
 from datetime import date
 from loguru import logger
 from pprint import pprint
@@ -81,8 +80,12 @@ def download(
     ftype = "DBC"
     if year >= 1994 and year < 2008:
         ftp.cwd("/dissemin/publicos/SIASUS/199407_200712/Dados")
+        logger.debug("Changing FTP work dir to: /dissemin/publicos/SIASUS/199407_200712/Dados")
+
     elif year >= 2008:
         ftp.cwd("/dissemin/publicos/SIASUS/200801_/Dados")
+        logger.debug("Changing FTP work dir to: /dissemin/publicos/SIASUS/200801_/Dados")
+        
     else:
         raise ValueError("SIA does not contain data before 1994")
 
@@ -152,7 +155,7 @@ def _fetch_file(fname, ftp, ftype):
 
     os.unlink(fname)
     logger.debug(f"{fname} removed")
-    
+
     return df
 
 

--- a/pysus/online_data/SIA.py
+++ b/pysus/online_data/SIA.py
@@ -2,20 +2,20 @@
 Downloads SIA data from Datasus FTP server
 Created on 21/09/18
 by fccoelho
-Modified on 18/04/21
+Modified on 22/11/22
 by bcbernardo
 license: GPL V3 or Later
 """
 
 import os
-import warnings
-from datetime import date
-from ftplib import FTP
-from typing import Dict, List, Optional, Tuple, Union
-from pprint import pprint
-
 import pandas as pd
+
+from ftplib import FTP
 from dbfread import DBF
+from datetime import date
+from loguru import logger
+from pprint import pprint
+from typing import Dict, List, Optional, Tuple, Union
 
 from pysus.online_data import CACHEPATH
 from pysus.utilities.readdbc import read_dbc, read_dbc_dbf, dbc2dbf
@@ -77,6 +77,7 @@ def download(
         group = [group]
     ftp = FTP("ftp.datasus.gov.br")
     ftp.login()
+    logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
     ftype = "DBC"
     if year >= 1994 and year < 2008:
         ftp.cwd("/dissemin/publicos/SIASUS/199407_200712/Dados")
@@ -99,7 +100,7 @@ def download(
             # NOTE: raise Warning instead of ValueError for
             # backwards-compatibility with older behavior of returning
             # (PA, None) for calls after 1994 and before Jan, 2008
-            warnings.warn(
+            logger.warn(
                 f"SIA does not contain data for {gname} "
                 f"before {available_date:%d/%m/%Y}"
             )
@@ -110,12 +111,14 @@ def download(
         # Check in Cache
         cachefile = os.path.join(CACHEPATH, "SIA_" + fname.split(".")[0] + "_.parquet")
         if os.path.exists(cachefile):
+            logger.info(f"Local parquet file found at {cachefile}")
             df = pd.read_parquet(cachefile)
         else:
             try:
                 df = _fetch_file(fname, ftp, ftype)
                 if cache and df:  # saves to cache if df is not None
                     df.to_parquet(cachefile)
+                    logger.info(f"Data stored as parquet at {cachefile}")
             except Exception as e:
                 df = None
                 print(e)
@@ -148,6 +151,7 @@ def _fetch_file(fname, ftp, ftype):
     df = read_dbc_dbf(fname)
 
     os.unlink(fname)
+    logger.debug(f"{fname} removed")
     return df
 
 
@@ -160,6 +164,7 @@ def download_multiples(fnames, ftp):
             ftp.retrbinary(f"RETR {fn}", fobj.write)
             dbc2dbf(fnfull, fnfull.replace('.dbc', '.dbf'))
             os.unlink(fnfull)
+            logger.debug(f"{fnfull} removed")
         except Exception as exc:
             raise Exception(f"Retrieval of file {fn} failed with the following error:\n {exc}")
 

--- a/pysus/online_data/SIH.py
+++ b/pysus/online_data/SIH.py
@@ -6,10 +6,11 @@ license: GPL V3 or Later
 """
 
 import os
-from ftplib import FTP
-
 import pandas as pd
+
+from ftplib import FTP
 from dbfread import DBF
+from loguru import logger
 
 from pysus.online_data import CACHEPATH
 from pysus.utilities.readdbc import read_dbc
@@ -28,39 +29,57 @@ def download(state: str, year: int, month: int, cache: bool = True) -> object:
     year2 = int(str(year)[-2:])
     year2 = str(year2).zfill(2)
     month = str(month).zfill(2)
+
     if year < 1992:
         raise ValueError("SIH does not contain data before 1994")
+
     if year < 2008:
         ftype = "DBC"
         path = "/dissemin/publicos/SIHSUS/199201_200712/Dados"
         fname = f"RD{state}{year2}{month}.dbc"
+
     if year >= 2008:
         ftype = "DBC"
         path = f"/dissemin/publicos/SIHSUS/200801_/Dados"
         fname = f"RD{state}{year2}{month}.dbc"
+
     cachefile = os.path.join(CACHEPATH, "SIH_" + fname.split(".")[0] + "_.parquet")
+
     if os.path.exists(cachefile):
+        logger.info(f"Local parquet file found at {cachefile}")
         df = pd.read_parquet(cachefile)
+
         return df
 
     df = _fetch_file(fname, path, ftype)
+    
     if cache:
         df.to_parquet(cachefile)
+        logger.info(f"Data stored as parquet at {cachefile}")
+
     return df
 
 
 def _fetch_file(fname, path, ftype):
     ftp = FTP("ftp.datasus.gov.br")
     ftp.login()
+    logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
     ftp.cwd(path)
+
     try:
         ftp.retrbinary("RETR {}".format(fname), open(fname, "wb").write)
+
     except:
         raise Exception("File {} not available".format(fname))
+
     if ftype == "DBC":
         df = read_dbc(fname, encoding="iso-8859-1")
+
     elif ftype == "DBF":
         dbf = DBF(fname, encoding="iso-8859-1")
         df = pd.DataFrame(list(dbf))
+
     os.unlink(fname)
+    logger.debug(f"{fname} removed")
+
     return df

--- a/pysus/online_data/SIH.py
+++ b/pysus/online_data/SIH.py
@@ -65,6 +65,7 @@ def _fetch_file(fname, path, ftype):
     ftp.login()
     logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
     ftp.cwd(path)
+    logger.debug(f"Changing FTP work dir to: {path}")
 
     try:
         ftp.retrbinary("RETR {}".format(fname), open(fname, "wb").write)

--- a/pysus/online_data/SIM.py
+++ b/pysus/online_data/SIM.py
@@ -6,10 +6,11 @@ license: GPL V3 or Later
 """
 
 import os
-from ftplib import FTP, error_perm
-
 import pandas as pd
+
 from dbfread import DBF
+from loguru import logger
+from ftplib import FTP, error_perm
 
 from pysus.online_data import CACHEPATH
 from pysus.utilities.readdbc import read_dbc
@@ -26,23 +27,31 @@ def download(state, year, cache=True, folder=None):
     state = state.upper()
     ftp_dir = ""
     fname = ""
+
     if year < 1979:
         raise ValueError("SIM does not contain data before 1979")
+
     elif year >= 1996:
         ftp_dir = "/dissemin/publicos/SIM/CID10/DORES"
         fname = "DO{}{}.DBC".format(state, year)
+
     else:
         ftp_dir = "/dissemin/publicos/SIM/CID9/DORES"
         fname = fname = "DOR{}{}.DBC".format(state, year2)
 
     cache_fail = False
     cachefile = os.path.join(CACHEPATH, "SIM_" + fname.split(".")[0] + "_.parquet")
+
     if folder:
         fname = "{}/{}".format(folder, fname)
+
     elif cache:
         if os.path.exists(cachefile):
+            logger.info(f"Local parquet file found at {cachefile}")
             df = pd.read_parquet(cachefile)
+
             return df
+
         else:
             cache_fail = True
 
@@ -50,149 +59,224 @@ def download(state, year, cache=True, folder=None):
     if not folder and (cache_fail or not cache):
         ftp = FTP("ftp.datasus.gov.br")
         ftp.login()
+        logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
         ftp.cwd(ftp_dir)
+        logger.debug(f"Changing FTP work dir to: {ftp_dir}")
 
         try:
             ftp.retrbinary("RETR {}".format(fname), open(fname, "wb").write)
+
         except error_perm:
             try:
                 ftp.retrbinary("RETR {}".format(fname.upper()), open(fname, "wb").write)
+
             except:
                 raise Exception("File {} not available".format(fname))
 
     df = read_dbc(fname, encoding="iso-8859-1")
 
     df.to_parquet(cachefile)
+    logger.info(f"Data stored as parquet at {cachefile}")
 
     os.unlink(fname)
+    logger.debug(f"{fname} removed")
     return df
 
 
 def get_CID10_chapters_table(cache=True):
     """
     Fetch the CID10 chapters table
-    :param cache:
-    :return:
+    :param cache: If set to True, stores data as parquets.
+    :return: Pandas DataFrame
     """
     ftp = FTP("ftp.datasus.gov.br")
     ftp.login()
+    logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
     ftp.cwd("/dissemin/publicos/SIM/CID10/TABELAS")
+    logger.debug("Changing FTP work dir to: /dissemin/publicos/SIM/CID10/TABELAS")
+
     fname = "CIDCAP10.DBF"
     cachefile = os.path.join(CACHEPATH, "SIM_" + fname.split(".")[0] + "_.parquet")
+    
     if os.path.exists(cachefile):
+        logger.info(f"Local parquet file found at {cachefile}")
         df = pd.read_parquet(cachefile)
+
         return df
+        
     try:
         ftp.retrbinary("RETR {}".format(fname), open(fname, "wb").write)
+
     except error_perm:
         raise Exception("Could not download {}".format(fname))
+
     dbf = DBF(fname, encoding="iso-8859-1")
     df = pd.DataFrame(list(dbf))
+
     if cache:
         df.to_parquet(cachefile)
+        logger.info(f"Data stored as parquet at {cachefile}")
+
     os.unlink(fname)
+    logger.debug(f"{fname} removed")
+
     return df
 
 
 def get_CID10_table(cache=True):
     """
     Fetch the CID10 table
-    :param cache:
-    :return:
+    :param cache: If set to True, stores data as parquets.
+    :return: Pandas DataFrame
     """
     ftp = FTP("ftp.datasus.gov.br")
     ftp.login()
+    logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
     ftp.cwd("/dissemin/publicos/SIM/CID10/TABELAS")
+    logger.debug("Changing FTP work dir to: /dissemin/publicos/SIM/CID10/TABELAS")
+
     fname = "CID10.DBF"
     cachefile = os.path.join(CACHEPATH, "SIM_" + fname.split(".")[0] + "_.parquet")
+
     if os.path.exists(cachefile):
+        logger.info(f"Local parquet file found at {cachefile}")
         df = pd.read_parquet(cachefile)
+
         return df
+
     try:
         ftp.retrbinary("RETR {}".format(fname), open(fname, "wb").write)
+
     except error_perm:
         raise Exception("Could not download {}".format(fname))
+
     dbf = DBF(fname, encoding="iso-8859-1")
     df = pd.DataFrame(list(dbf))
+
     if cache:
         df.to_parquet(cachefile)
+        logger.info(f"Data stored as parquet at {cachefile}")
+
     os.unlink(fname)
+    logger.debug(f"{fname} removed")
+
     return df
 
 
 def get_CID9_table(cache=True):
     """
     Fetch the CID9 table
-    :param cache:
-    :return:
+    :param cache: If set to True, stores data as parquets.
+    :return: Pandas DataFrame
     """
     ftp = FTP("ftp.datasus.gov.br")
     ftp.login()
+    logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
     ftp.cwd("/dissemin/publicos/SIM/CID9/TABELAS")
+    logger.debug("Changing FTP work dir to: /dissemin/publicos/SIM/CID9/TABELAS")
+
     fname = "CID9.DBF"
     cachefile = os.path.join(CACHEPATH, "SIM_" + fname.split(".")[0] + "_.parquet")
+
     if os.path.exists(cachefile):
+        logger.info(f"Local parquet file found at {cachefile}")
         df = pd.read_parquet(cachefile)
+
         return df
+
     try:
         ftp.retrbinary("RETR {}".format(fname), open(fname, "wb").write)
+
     except error_perm:
         raise Exception("Could not download {}".format(fname))
+
     dbf = DBF(fname, encoding="iso-8859-1")
     df = pd.DataFrame(list(dbf))
+
     if cache:
         df.to_parquet(cachefile)
+        logger.info(f"Data stored as parquet at {cachefile}")
+
     os.unlink(fname)
+    logger.debug(f"{fname} removed")
+
     return df
 
 
 def get_municipios(cache=True):
     """
     Get municipality metadata
-    :param cache:
-    :return:
+    :param cache: If set to True, stores data as parquets.
+    :return: Pandas DataFrame
     """
     ftp = FTP("ftp.datasus.gov.br")
     ftp.login()
+    logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
     ftp.cwd("/dissemin/publicos/SIM/CID10/TABELAS")
+    logger.debug("Changing FTP work dir to: /dissemin/publicos/SIM/CID10/TABELAS")
+
     fname = "CADMUN.DBF"
     cachefile = os.path.join(CACHEPATH, "SIM_" + fname.split(".")[0] + "_.parquet")
+
     if os.path.exists(cachefile):
+        logger.info(f"Local parquet file found at {cachefile}")
         df = pd.read_parquet(cachefile)
+
         return df
+        
     try:
         ftp.retrbinary("RETR {}".format(fname), open(fname, "wb").write)
+
     except:
         raise Exception("Could not download {}".format(fname))
+
     dbf = DBF(fname, encoding="iso-8859-1")
     df = pd.DataFrame(list(dbf))
+
     if cache:
         df.to_parquet(cachefile)
+        logger.info(f"Data stored as parquet at {cachefile}")
+
     os.unlink(fname)
+    logger.debug(f"{fname} removed")
+
     return df
 
 
 def get_ocupations(cache=True):
     """
     Fetch ocupations table
-    :param cache:
-    :return:
+    :param cache: If set to True, stores data as parquets.
+    :return: Pandas DataFrame
     """
     ftp = FTP("ftp.datasus.gov.br")
     ftp.login()
+    logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
     ftp.cwd("/dissemin/publicos/SIM/CID10/TABELAS")
+    logger.debug("Changing FTP work dir to: /dissemin/publicos/SIM/CID10/TABELAS")
     fname = "TABOCUP.DBF"
     cachefile = os.path.join(CACHEPATH, "SIM_" + fname.split(".")[0] + "_.parquet")
+
     if os.path.exists(cachefile):
+        logger.info(f"Local parquet file found at {cachefile}")
         df = pd.read_parquet(cachefile)
+
         return df
+
     try:
         ftp.retrbinary("RETR {}".format(fname), open(fname, "wb").write)
+
     except:
         raise Exception("Could not download {}".format(fname))
+
     dbf = DBF(fname, encoding="iso-8859-1")
     df = pd.DataFrame(list(dbf))
+
     if cache:
         df.to_parquet(cachefile)
+        logger.info(f"Data stored as parquet at {cachefile}")
+
     os.unlink(fname)
+    logger.debug(f"{fname} removed")
+
     return df

--- a/pysus/online_data/SINAN.py
+++ b/pysus/online_data/SINAN.py
@@ -1,6 +1,4 @@
-import logging
 import shutil
-import warnings
 from ftplib import FTP
 from pathlib import Path
 from loguru import logger
@@ -65,7 +63,7 @@ def get_available_years(disease, return_path=False):
                         FINAIS and PRELIM while downloading the datasets.
     :return: A list of DBC files from a specific disease found in the FTP Server.
     """
-    logger.warn(
+    logger.warning(
         "Now SINAN tables are no longer split by state. Returning countrywide years"
     ) #legacy
 
@@ -131,7 +129,7 @@ def download(disease, year, return_chunks=False, data_path="/tmp/pysus"):
     if year2 < first_year: #legacy
         raise ValueError(f"SINAN does not contain data before {first_year}")
 
-    logger.warn(
+    logger.warning(
         "Now SINAN tables are no longer split by state. Returning country table" 
     ) #legacy
     
@@ -171,14 +169,14 @@ def download(disease, year, return_chunks=False, data_path="/tmp/pysus"):
         return partquet_dir
 
     except Exception as e:
-        logging.error(e)
+        logger.error(e)
 
     finally:
         out.unlink(missing_ok=True)
         dbf.unlink(missing_ok=True)
         Path(fname).unlink(missing_ok=True)
         Path(f'{fname[:-4]}.dbf').unlink(missing_ok=True)
-        logger.info("🧹 Cleaning data residues")
+        logger.debug("🧹 Cleaning data residues")
 
 
 def download_all_years_in_chunks(disease, data_dir="/tmp/pysus"):

--- a/pysus/online_data/SINAN.py
+++ b/pysus/online_data/SINAN.py
@@ -3,13 +3,14 @@ import shutil
 import warnings
 from ftplib import FTP
 from pathlib import Path
+from loguru import logger
 
 from pysus.online_data import (
     _fetch_file,
     chunk_dbfiles_into_parquets,
     parquets_to_dataframe,
 )
-from pysus.utilities.readdbc import dbc2dbf
+
 
 agravos = {
     "Animais Peçonhentos": "ANIM",
@@ -64,7 +65,7 @@ def get_available_years(disease, return_path=False):
                         FINAIS and PRELIM while downloading the datasets.
     :return: A list of DBC files from a specific disease found in the FTP Server.
     """
-    warnings.warn(
+    logger.warn(
         "Now SINAN tables are no longer split by state. Returning countrywide years"
     ) #legacy
 
@@ -74,10 +75,12 @@ def get_available_years(disease, return_path=False):
 
     ftp = FTP("ftp.datasus.gov.br")
     ftp.login()
+    logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
 
     dbcs = []
 
     ftp.cwd(fpath)
+    logger.debug(f"Changing FTP work dir to: {fpath}")
     for dbc in ftp.nlst(f"{agravos[disease]}BR*.dbc"):
         if return_path:
             dbcs.append(f"{fpath}/{dbc}")
@@ -85,6 +88,7 @@ def get_available_years(disease, return_path=False):
             dbcs.append(dbc)
         
     ftp.cwd(ppath)
+    logger.debug(f"Changing FTP work dir to: {ppath}")
     for dbc in ftp.nlst(f"{agravos[disease]}BR*.dbc"):
         if return_path:
             dbcs.append(f"{ppath}/{dbc}")
@@ -127,7 +131,7 @@ def download(disease, year, return_chunks=False, data_path="/tmp/pysus"):
     if year2 < first_year: #legacy
         raise ValueError(f"SINAN does not contain data before {first_year}")
 
-    warnings.warn(
+    logger.warn(
         "Now SINAN tables are no longer split by state. Returning country table" 
     ) #legacy
     
@@ -138,20 +142,24 @@ def download(disease, year, return_chunks=False, data_path="/tmp/pysus"):
     #Create the path where the data will be downloaded locally
     data_path = Path(data_path)
     data_path.mkdir(exist_ok=True, parents=True)
+    logger.debug(f"{data_path} directory created.")
+
     out = Path(data_path) / fname
     dbf = Path(f"{str(out)[:-4]}.dbf")
 
     ftp = FTP("ftp.datasus.gov.br")
     ftp.login()
+    logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
 
     if not Path(out).exists():
+        logger.debug(f"{fname} file not found. Proceeding to download..")
         try:
             _fetch_file(fname, sus_path, "DBC", return_df=False)
             shutil.move(Path(fname), data_path)
-            logging.info(f"{fname} downloaded at {data_path}")
+            logger.info(f"{fname} downloaded at {data_path}")
 
         except Exception as e:
-            logging.error(e)
+            logger.error(e)
 
     try:
         partquet_dir = chunk_dbfiles_into_parquets(str(out))
@@ -170,6 +178,7 @@ def download(disease, year, return_chunks=False, data_path="/tmp/pysus"):
         dbf.unlink(missing_ok=True)
         Path(fname).unlink(missing_ok=True)
         Path(f'{fname[:-4]}.dbf').unlink(missing_ok=True)
+        logger.info("🧹 Cleaning data residues")
 
 
 def download_all_years_in_chunks(disease, data_dir="/tmp/pysus"):
@@ -197,6 +206,8 @@ def download_all_years_in_chunks(disease, data_dir="/tmp/pysus"):
             )
 
             parquets.append(parquet_dir)
+
+    [logger.debug(f"{parquet} downloaded.") for parquet in parquets]
 
     return parquets
 

--- a/pysus/online_data/sinasc.py
+++ b/pysus/online_data/sinasc.py
@@ -6,9 +6,10 @@ license: GPL V3 or Later
 """
 import os
 import warnings
-from ftplib import FTP
-
 import pandas as pd
+
+from ftplib import FTP
+from loguru import logger
 
 from pysus.online_data import CACHEPATH
 from pysus.utilities.readdbc import read_dbc
@@ -25,34 +26,56 @@ def download(state, year, cache=True):
     """
     assert len(str(year)) == 4
     state = state.upper()
+
     if year < 1994:
         raise ValueError("SINASC does not contain data before 1994")
+
     ftp = FTP("ftp.datasus.gov.br")
     ftp.login()
+    logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
+
     if year >= 1996:
         ftp.cwd("/dissemin/publicos/SINASC/NOV/DNRES")
+        logger.debug("Changing FTP work dir to: /dissemin/publicos/SINASC/NOV/DNRES")
         fname = "DN{}{}.DBC".format(state, year)
+
     else:
         ftp.cwd("/dissemin/publicos/SINASC/ANT/DNRES")
+        logger.debug("Changing FTP work dir to: /dissemin/publicos/SINASC/ANT/DNRES")
         fname = "DNR{}{}.DBC".format(state, str(year)[-2:])
+
     cachefile = os.path.join(CACHEPATH, "SINASC_" + fname.split(".")[0] + "_.parquet")
+
     if os.path.exists(cachefile):
+        logger.info(f"Local parquet file found at {cachefile}")
         df = pd.read_parquet(cachefile)
+
         return df
 
     ftp.retrbinary("RETR {}".format(fname), open(fname, "wb").write)
     df = read_dbc(fname, encoding="iso-8859-1")
+
     if cache:
         df.to_parquet(cachefile)
+        logger.info(f"Data stored as parquet at {cachefile}")
+
     os.unlink(fname)
+    logger.debug(f"{fname} removed")
+
     return df
 
 
 def get_available_years(state):
     ftp = FTP("ftp.datasus.gov.br")
     ftp.login()
+    logger.debug(f"Stablishing connection with ftp.datasus.gov.br.\n{ftp.welcome}")
+
     ftp.cwd("/dissemin/publicos/SINASC/ANT/DNRES")
+    logger.debug("Changing FTP work dir to: /dissemin/publicos/SINASC/ANT/DNRES")
     res = ftp.nlst(f"DNR{state}*.*")
+
     ftp.cwd("/dissemin/publicos/SINASC/NOV/DNRES")
+    logger.debug("Changing FTP work dir to: /dissemin/publicos/SINASC/NOV/DNRES")
     res += ftp.nlst(f"DN{state}*.*")
+    
     return res

--- a/pysus/online_data/vaccine.py
+++ b/pysus/online_data/vaccine.py
@@ -19,6 +19,9 @@ from requests.auth import HTTPBasicAuth
 from pysus.online_data import CACHEPATH
 
 
+# logger.add(sink=sys.stderr, level='INFO')
+
+
 def download_covid(uf=None, only_header=False):
     """
     Download covid vaccination data for a give UF

--- a/pysus/online_data/vaccine.py
+++ b/pysus/online_data/vaccine.py
@@ -19,9 +19,6 @@ from requests.auth import HTTPBasicAuth
 from pysus.online_data import CACHEPATH
 
 
-# logger.add(sink=sys.stderr, level='INFO')
-
-
 def download_covid(uf=None, only_header=False):
     """
     Download covid vaccination data for a give UF

--- a/pysus/online_data/vaccine.py
+++ b/pysus/online_data/vaccine.py
@@ -62,6 +62,7 @@ def download_covid(uf=None, only_header=False):
     
     logger.info(f"{tempfile} stored at {CACHEPATH}.")
     df = pd.read_csv(tempfile, chunksize=5000)
+    
     return df
 
 

--- a/pysus/online_data/vaccine.py
+++ b/pysus/online_data/vaccine.py
@@ -6,20 +6,15 @@ This module contains function to download from specific campains:
 - COVID-19 in 2020-2021 Downloaded as described [here](http://opendatasus.saude.gov.br/dataset/b772ee55-07cd-44d8-958f-b12edd004e0b/resource/5916b3a4-81e7-4ad5-adb6-b884ff198dc1/download/manual_api_vacina_covid-19.pdf)
 """
 import os
-# import sys
-import time
 import json
-# from loguru import logger
 import requests
 import pandas as pd
 
+from loguru import logger
 from json import JSONDecodeError
 from requests.auth import HTTPBasicAuth
 
 from pysus.online_data import CACHEPATH
-
-
-# logger.add(sink=sys.stderr, level='INFO')
 
 
 def download_covid(uf=None, only_header=False):
@@ -39,6 +34,8 @@ def download_covid(uf=None, only_header=False):
     else:
         UF = uf.upper()
         query = {"query": {"match": {"paciente_endereco_uf": UF}}, "size": 10000}
+    
+    logger.info(f"Searching for COVID data of {UF}")
     tempfile = os.path.join(CACHEPATH, f"Vaccine_temp_{UF}.csv.gz")
     if os.path.exists(tempfile):
         print(
@@ -51,8 +48,7 @@ def download_covid(uf=None, only_header=False):
 
     if only_header:
         df = pd.DataFrame(next(data_gen))
-        # logger.warning(f"Downloading data sample visualization of {df.shape[0]} rows...")
-        time.sleep(0.3)
+        logger.warning(f"Downloading data sample for visualization of {df.shape[0]} rows...")
         return df
 
     h = 1
@@ -64,7 +60,7 @@ def download_covid(uf=None, only_header=False):
         else:
             df.to_csv(tempfile, mode="a", header=False)
     
-    # logger.info(f"{tempfile} stored at {CACHEPATH}.")
+    logger.info(f"{tempfile} stored at {CACHEPATH}.")
     df = pd.read_csv(tempfile, chunksize=5000)
     return df
 
@@ -100,7 +96,8 @@ def elasticsearch_fetch(uri, auth, json_body={}):
         try:
             if resp["hits"]["hits"] == []:
                 break
-        except KeyError:
+        except KeyError as e:
+            logger.error(e)
             print(resp)
         total += len(resp["hits"]["hits"])
         print(f"Downloaded {total} records\r", end="")

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,7 +4,7 @@ license-file = LICENSE
 [build_sphinx]
 project = 'PySUS'
 version = 0.6
-release = 0.6.0
+release = 0.6.3
 source-dir = './docs/source'
 
 [flake8]


### PR DESCRIPTION
Fix #103 


NOTES:
Loguru standard log already throws log at `sys.stderr`. No need for configuring its sink. 