### PR TITLE
chore: update deprecated plugin to new package

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -7,7 +7,7 @@
       "preset": "conventionalcommits"
     }],
     [
-      "@google/semantic-release-replace-plugin",
+      "semantic-release-replace-plugin",
       {
         "replacements": [
           {

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ SEMANTIC_RELEASE = npx --yes \
           -p "@semantic-release/exec" \
           -p "@semantic-release/github" \
           -p "@semantic-release/git" \
-          -p "@google/semantic-release-replace-plugin" \
+          -p "semantic-release-replace-plugin" \
           semantic-release
 
 


### PR DESCRIPTION
This is a PR to update the semantic-release-replace-plugin to the [new package](https://www.npmjs.com/package/semantic-release-replace-plugin) from the [deprecated version](https://www.npmjs.com/package/@google/semantic-release-replace-plugin).