### PR TITLE
moved dockerfile to avoid docker build error and changed entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -51,4 +51,4 @@ RUN mamba env create -n $ENV_NAME --file /tmp/dev.yaml \
 
 WORKDIR /home/pysus/Notebooks
 
-ENTRYPOINT ["bash", "/activate.sh"]
+ENTRYPOINT ["bash", "/activate.sh", "jupyter", "notebook", "--port=8888", "--ip=0.0.0.0"]


### PR DESCRIPTION
I moved dockerfile to root directory to avoid build errors and changed entrypoint command to run jupyter notebook correctly.