### PR TITLE
Avoid eager FTP connection when importing SINAN helpers

### DIFF
--- a/pysus/online_data/SINAN.py
+++ b/pysus/online_data/SINAN.py
@@ -1,3 +1,4 @@
+from functools import lru_cache
 from pathlib import Path
 from typing import Union
 
@@ -5,12 +6,15 @@ import pandas as pd
 from pysus.ftp import CACHEPATH
 from pysus.ftp.databases.sinan import SINAN
 
-sinan = SINAN().load()
+
+@lru_cache(maxsize=1)
+def _get_sinan() -> SINAN:
+    return SINAN().load()
 
 
 def list_diseases() -> dict:
     """List available diseases on SINAN"""
-    return sinan.diseases
+    return _get_sinan().diseases
 
 
 def get_available_years(disease_code: str) -> list:
@@ -21,6 +25,7 @@ def get_available_years(disease_code: str) -> list:
     :return:
         A list of DBC files from a specific disease found in the FTP Server.
     """
+    sinan = _get_sinan()
     files = sinan.get_files(dis_code=disease_code)
     return sorted(list(set(sinan.describe(f)["year"] for f in files)))
 
@@ -37,6 +42,7 @@ def download(
     :param data_path: The directory where the file will be downloaded to.
     :return: list of downloaded files.
     """
+    sinan = _get_sinan()
     files = sinan.get_files(dis_code=diseases, year=years)
     return sinan.download(files, local_dir=data_path)
 

--- a/pysus/tests/test_sinan_online_data.py
+++ b/pysus/tests/test_sinan_online_data.py
@@ -1,0 +1,45 @@
+import importlib
+import sys
+import unittest
+from unittest.mock import Mock, patch
+
+
+class TestSINANOnlineDataImport(unittest.TestCase):
+    MODULE = "pysus.online_data.SINAN"
+
+    def tearDown(self):
+        sys.modules.pop(self.MODULE, None)
+
+    def test_import_does_not_connect_to_ftp(self):
+        sys.modules.pop(self.MODULE, None)
+
+        with patch(
+            "pysus.ftp.databases.sinan.SINAN.load",
+            side_effect=AssertionError("load() should not run on import"),
+        ):
+            module = importlib.import_module(self.MODULE)
+
+        self.assertTrue(hasattr(module, "_get_sinan"))
+
+    def test_sinan_connection_is_loaded_lazily_and_cached(self):
+        sys.modules.pop(self.MODULE, None)
+        fake_sinan = Mock()
+        fake_sinan.diseases = {"DENG": "Dengue"}
+        fake_sinan.get_files.return_value = ["f1", "f2"]
+        fake_sinan.describe.side_effect = [
+            {"year": "2024"},
+            {"year": "2023"},
+        ]
+
+        with patch(
+            "pysus.ftp.databases.sinan.SINAN.load", return_value=fake_sinan
+        ) as mock_load:
+            module = importlib.import_module(self.MODULE)
+
+            self.assertEqual(module.list_diseases(), {"DENG": "Dengue"})
+            self.assertEqual(module.get_available_years("DENG"), ["2023", "2024"])
+            mock_load.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Closes #242

## Summary
- defer creation of the SINAN FTP-backed client until one of the public helper functions is actually called
- cache the loaded client so repeated calls keep the previous behavior without reconnecting on every use
- add a regression test that verifies importing `pysus.online_data.SINAN` no longer calls `SINAN.load()` eagerly

## Testing
- `uv venv .venv`
- `source .venv/bin/activate`
- `uv pip install -e .`
- `python -m unittest pysus.tests.test_sinan_online_data -v`
