### PR TITLE
docs: remove unused CACHEPATH import from configuration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,6 @@ df = pysus.read_parquet(paths, sql="SELECT * WHERE column > 100").df()
 ### Cache Directory
 
 ```python
-from pysus import CACHEPATH
 import os
 
 os.environ['PYSUS_CACHEPATH'] = '/my/custom/path'


### PR DESCRIPTION
## Description

Removed the unused `CACHEPATH` import from the Cache Directory configuration example in the documentation.

### Changes

* Removed `from pysus import CACHEPATH`
* Kept the `os` import and `PYSUS_CACHEPATH` environment variable example unchanged

This makes the documentation example cleaner and avoids showing an unused import.
