### PR TITLE
test(ftp): verify no FTP connection on import or initialization

### DIFF
--- a/pysus/tests/api/ftp/test_client.py
+++ b/pysus/tests/api/ftp/test_client.py
@@ -207,3 +207,24 @@ async def test_list_directory_calls_ftp_methods(ftp_client):
 
         mock_ftp_internal.cwd.assert_called_once_with("/test/path")
         mock_ftp_internal.retrlines.assert_called_once()
+
+
+def test_ftp_init_does_not_connect():
+    """Verify that instantiating FTP does not open an FTP connection."""
+    with patch("pysus.api.ftp.client.FTPLib") as mock_ftplib:
+        client = FTP()
+        assert client.ftp is None
+        mock_ftplib.assert_not_called()
+
+
+def test_import_does_not_connect_ftp():
+    """Verify importing pysus modules does not connect to FTP server."""
+    with patch("ftplib.FTP") as mock_ftplib:
+        import pysus  # noqa: F401
+        import pysus.api  # noqa: F401
+        import pysus.api.ftp  # noqa: F401
+        from pysus.api.client import PySUS
+
+        pysus_instance = PySUS()
+        assert pysus_instance._ftp is None
+        mock_ftplib.assert_not_called()


### PR DESCRIPTION
## Description

This PR adds regression tests to ensure importing \pysus\ modules and instantiating \FTP\ or \PySUS\ clients does not trigger an eager FTP network connection to DATASUS servers.

## Motivation

In environments with restricted network access or during offline development, importing library modules should be fast and reliable without attempting unrequested network connections or failing with socket errors.

## Changes

- Added unit tests in \pysus/tests/api/ftp/test_client.py\:
  - \	est_ftp_init_does_not_connect\: Verifies \FTP()\ instantiation leaves internal connection idle without connecting.
  - \	est_import_does_not_connect_ftp\: Verifies importing \pysus\, \pysus.api\, \pysus.api.ftp\, and initializing \PySUS()\ performs zero calls to \tplib.FTP\.

## Validation

- Full test suite: **660 passed** (\pytest -q\).
- Linters passed: \lack\, \isort\, and \lake8\ with 0 errors.