### PR TITLE
fix(release): remove @semantic-release/git, use PR for version bumps

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,6 @@
 {
   "branches": ["main"],
+  "repositoryUrl": "https://github.com/AlertaDengue/PySUS.git",
   "tagFormat": "${version}",
   "plugins": [
     [
@@ -12,8 +13,8 @@
         "replacements": [
           {
             "files": ["pysus/__init__.py"],
-            "from": "return \".*\"  # changed by semantic-release",
-            "to": "return \"${nextRelease.version}\"  # changed by semantic-release",
+            "from": "^return \".*\"",
+            "to": "return \"${nextRelease.version}\"",
             "results": [
               {
                 "file": "pysus/__init__.py",
@@ -26,8 +27,8 @@
           },
           {
             "files": ["pyproject.toml"],
-            "from": "version = \".*\"  # changed by semantic-release",
-            "to": "version = \"${nextRelease.version}\"  # changed by semantic-release",
+            "from": "^version = \".*\"",
+            "to": "version = \"${nextRelease.version}\"",
             "results": [
               {
                 "file": "pyproject.toml",

--- a/pysus/__init__.py
+++ b/pysus/__init__.py
@@ -17,7 +17,7 @@ def get_version() -> str:
     try:
         return importlib_metadata.version(__name__)
     except importlib_metadata.PackageNotFoundError:  # pragma: no cover
-        return "2.8.0"  # changed by semantic-release"
+        return "2.8.0"  # changed by semantic-release
 
 
 version: str = get_version()


### PR DESCRIPTION
Branch protection requires PRs on main. Remove the git plugin that tried to push directly, and add a workflow step that creates a version-bump PR after each release.