### PR TITLE
feat: add SIM death-certificate column metadata

### DIFF
--- a/docs/source/guides/metadata.rst
+++ b/docs/source/guides/metadata.rst
@@ -100,3 +100,24 @@ any network access:
 
    local = await file.download()
    print(local.metadata.structure.columns)
+
+Curated column descriptions
+---------------------------
+
+The Saude catalog can apply curated column descriptions during a sync. The
+SIM Declaração de Óbito resource is covered by
+``pysus/api/saude/schemas/vigilanciameioambiente.yaml``. Its field names and
+Portuguese descriptions are transcribed from the official SIM data dictionary
+(updated July 2025); no records are bundled with PySUS.
+
+The schema is keyed by the downloaded resource basename, so it can be applied
+without relying on a particular data file or downloading a sample:
+
+.. code-block:: python
+
+   from pysus.api.saude.schemas import load_endpoint_columns
+
+   columns = load_endpoint_columns(
+       "vigilanciameioambiente", "DO24OPEN_csv"
+   )
+   assert any(column["name"] == "TIPOBITO" for column in columns)

--- a/pysus/api/saude/schemas/vigilanciameioambiente.yaml
+++ b/pysus/api/saude/schemas/vigilanciameioambiente.yaml
@@ -1,0 +1,47 @@
+# Column descriptions for the SIM Declaração de Óbito (DO) resource.
+# Source: Ministry of Health, CGIAE, SIM data dictionary (updated 2025-07).
+# https://svs.aids.gov.br/daent/cgiae/sistemas-informacao/sim/documentacao/dicionario-de-dados-SIM-tabela-DO.pdf
+#
+# The same resource is exposed by the portal with different filenames. Keep
+# these aliases so catalog syncs can apply the same schema to the 2024 file.
+
+DO24OPEN_csv: &sim_do_columns
+  - name: TIPOBITO
+    type: string
+    description_pt: "Tipo do óbito: 1 - fetal; 2 - não fetal."
+    description_en: "Death type: 1 - fetal; 2 - non-fetal."
+  - name: DTOBITO
+    type: string
+    description_pt: "Data em que ocorreu o óbito, no formato ddmmaaaa."
+    description_en: "Date of death, in ddmmyyyy format."
+  - name: HORAOBITO
+    type: string
+    description_pt: "Horário do óbito, no padrão de 24 horas."
+    description_en: "Time of death, using the 24-hour format."
+  - name: DTNASC
+    type: string
+    description_pt: "Data de nascimento do falecido, no formato ddmmaaaa."
+    description_en: "Date of birth of the deceased, in ddmmyyyy format."
+  - name: SEXO
+    type: string
+    description_pt: "Sexo do falecido: M/1 masculino; F/2 feminino; I/0/9 ignorado."
+    description_en: "Sex of the deceased: M/1 male; F/2 female; I/0/9 unknown."
+  - name: RACACOR
+    type: string
+    description_pt: "Cor/raça informada: 1 branca; 2 preta; 3 amarela; 4 parda; 5 indígena."
+    description_en: "Self-reported race/colour: 1 white; 2 black; 3 yellow; 4 brown; 5 Indigenous."
+  - name: CODESTRES
+    type: string
+    description_pt: "Código da Unidade Federativa de residência."
+    description_en: "Code of the Federative Unit of residence."
+  - name: CODMUNRES
+    type: string
+    description_pt: "Código do município de residência."
+    description_en: "Code of the municipality of residence."
+  - name: CAUSABAS
+    type: string
+    description_pt: "Causa básica da Declaração de Óbito."
+    description_en: "Underlying cause of death on the death certificate."
+
+Mortalidade_Geral_2024_csv: *sim_do_columns
+Mortalidade Geral 2024: *sim_do_columns

--- a/pysus/tests/api/saude/test_schemas.py
+++ b/pysus/tests/api/saude/test_schemas.py
@@ -25,9 +25,7 @@ class TestLoadEndpointColumns:
         assert len(cols) > 0
 
     def test_load_sim_schema_from_resource_filename(self):
-        cols = load_endpoint_columns(
-            "vigilanciameioambiente", "DO24OPEN_csv"
-        )
+        cols = load_endpoint_columns("vigilanciameioambiente", "DO24OPEN_csv")
         assert len(cols) >= 8
         names = [c["name"] for c in cols]
         assert "TIPOBITO" in names
@@ -131,7 +129,9 @@ class TestApplyColumnDescriptions:
             dataset="vigilanciameioambiente",
             endpoint="DO24OPEN_csv",
         )
-        assert updated >= 8
+        # The return value counts schema definitions processed; the query
+        # below verifies that the matching database column was persisted.
+        assert updated == 9
         cursor.execute(
             "SELECT description FROM pysus.dataset_columns WHERE id = 1"
         )

--- a/pysus/tests/api/saude/test_schemas.py
+++ b/pysus/tests/api/saude/test_schemas.py
@@ -24,6 +24,15 @@ class TestLoadEndpointColumns:
         cols = load_endpoint_columns("arboviroses", "zikavirus")
         assert len(cols) > 0
 
+    def test_load_sim_schema_from_resource_filename(self):
+        cols = load_endpoint_columns(
+            "vigilanciameioambiente", "DO24OPEN_csv"
+        )
+        assert len(cols) >= 8
+        names = [c["name"] for c in cols]
+        assert "TIPOBITO" in names
+        assert "CODMUNRES" in names
+
     def test_unknown_dataset_returns_empty(self):
         cols = load_endpoint_columns("nonexistent", "endpoint")
         assert cols == []
@@ -91,6 +100,44 @@ class TestApplyColumnDescriptions:
         row = cursor.fetchone()
         assert row[0] is not None
         assert "notific" in row[0].lower()
+        con.close()
+
+    def test_applies_sim_description(self):
+        import duckdb
+
+        con = duckdb.connect(":memory:")
+        con.execute(
+            """
+            CREATE SCHEMA pysus;
+            CREATE TABLE pysus.dataset_columns (
+                id INTEGER PRIMARY KEY,
+                dataset_id INTEGER NOT NULL,
+                name VARCHAR NOT NULL,
+                type VARCHAR NOT NULL,
+                description VARCHAR,
+                nullable BOOLEAN DEFAULT true
+            );
+        """
+        )
+        cursor = con.cursor()
+        cursor.execute(
+            "INSERT INTO pysus.dataset_columns "
+            "(id, dataset_id, name, type, nullable) "
+            "VALUES (1, 1, 'TIPOBITO', 'VARCHAR', true)"
+        )
+        updated = apply_column_descriptions(
+            cursor,
+            dataset_id=1,
+            dataset="vigilanciameioambiente",
+            endpoint="DO24OPEN_csv",
+        )
+        assert updated >= 8
+        cursor.execute(
+            "SELECT description FROM pysus.dataset_columns WHERE id = 1"
+        )
+        row = cursor.fetchone()
+        assert row[0] is not None
+        assert "fetal" in row[0].lower()
         con.close()
 
     def test_no_update_for_unknown_dataset(self):


### PR DESCRIPTION
## Scope

This PR closes the metadata/documentation gap tracked by #232 for the SIM/DO
resource exposed by PySUS. It adds the official SIM 2024 column dictionary
with the portal aliases observed for this resource and documents the loader
contract.

## Files

- `pysus/api/saude/schemas/vigilanciameioambiente.yaml`
  - 9 SIM/DO columns with Portuguese and English descriptions.
  - aliases: `DO24OPEN_csv`, `Mortalidade_Geral_2024_csv`, and
    `Mortalidade Geral 2024`.
  - source: Ministry of Health / CGIAE SIM data dictionary.
- `pysus/tests/api/saude/test_schemas.py`
  - schema loading, aliases, required keys, DuckDB persistence, and unknown
    dataset coverage.
- `docs/source/guides/metadata.rst`
  - metadata catalog and application examples.

## Validation

The exact PR tree was built from the repository Dockerfile in a clean
`python:3.12-slim` environment.

- `docker build -t pysus-pr322-gates .` — PASS
- `pytest -q pysus/tests/api/saude/test_schemas.py` — PASS (13 tests)
- `pytest -q pysus/tests/api/saude` — PASS (213 tests)
- `sphinx-build -W -b html docs/source ...` — PASS after installing the
  missing `pandoc` package only in the disposable validation container
- `black --check` — PASS
- `isort --check-only` — PASS
- `flake8` — PASS
- `git diff --check` — PASS

The `apply_column_descriptions` return value counts schema definitions
processed; the test now asserts the exact 9 definitions and separately checks
that the matching DuckDB column receives its description.

The upstream image does not include Git, so the repository-level
`pre-commit run --all-files` command could not start in that image. Its
available formatter and linter hooks were run directly and passed. No
remote checks or reviews are currently reported on the PR.