### PR TITLE
fix: install conventional-changelog-writer v9

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,10 +7,12 @@ on:
         description: "Version tag for Docker image (e.g., 9.9.9-test)"
         required: false
         type: string
+
   push:
     branches: [main]
     tags:
       - "[0-9]*"
+
   pull_request:
     branches: [main]
 
@@ -20,102 +22,114 @@ concurrency:
 
 jobs:
   build:
-    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    name: Build and release
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Install poetry
-      run: pipx install poetry
+      - name: Install poetry
+        run: pipx install poetry
 
-    - uses: actions/setup-node@v4
-      with:
-        node-version: 22
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
 
-    - name: Test release
-      if: ${{ github.event_name != 'workflow_dispatch' }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: make release-dry
+      - name: Test release
+        if: github.event_name == 'pull_request'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: make release-dry
 
-    - name: Release
-      if: ${{ github.event_name == 'workflow_dispatch' }}
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        poetry config pypi-token.pypi ${PYPI_TOKEN}
-        make release
+      - name: Release
+        if: github.event_name == 'workflow_dispatch'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          poetry config pypi-token.pypi "${PYPI_TOKEN}"
+          make release
 
   docker-push:
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    name: Push Docker image
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     timeout-minutes: 15
+
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - name: Login to Docker Hub
-      uses: docker/login-action@v3
-      with:
-        username: alertadengue
-        password: ${{ secrets.DOCKER_TOKEN }}
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: alertadengue
+          password: ${{ secrets.DOCKER_TOKEN }}
 
-    - name: Extract version
-      id: version
-      run: |
-        if [ -n "${{ inputs.version }}" ]; then
-          echo "tag=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
-        else
-          echo "tag=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
-        fi
+      - name: Extract version
+        id: version
+        shell: bash
+        run: |
+          if [ -n "${{ inputs.version }}" ]; then
+            echo "tag=${{ inputs.version }}" >> "$GITHUB_OUTPUT"
+          else
+            echo "tag=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
+          fi
 
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
 
-    - name: Build and push
-      uses: docker/build-push-action@v6
-      with:
-        context: .
-        file: ./Dockerfile
-        push: true
-        tags: |
-          alertadengue/pysus:latest
-          alertadengue/pysus:${{ steps.version.outputs.tag }}
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: |
+            alertadengue/pysus:latest
+            alertadengue/pysus:${{ steps.version.outputs.tag }}
 
   docs:
-    if: ${{ !startsWith(github.ref, 'refs/tags/') }}
+    name: Build docs
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-    - uses: actions/setup-python@v5
-      with:
-        python-version: "3.12"
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
 
-    - name: Install system dependencies
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y pandoc
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y pandoc
 
-    - name: Install dependencies
-      run: |
-        pip install poetry
-        poetry config virtualenvs.create false
-        poetry install --no-root --with docs
+      - name: Install dependencies
+        run: |
+          pip install poetry
+          poetry config virtualenvs.create false
+          poetry install --no-root --with docs
 
-    - name: Build docs
-      run: |
-        cd docs
-        make html
+      - name: Build docs
+        run: |
+          cd docs
+          make html
 
   wheels:
     name: Build wheel (${{ matrix.os }})
+    if: github.event_name == 'pull_request' || github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
     runs-on: ${{ matrix.os }}
+
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
 
     steps:
       - uses: actions/checkout@v4
@@ -130,7 +144,8 @@ jobs:
       - name: Extract version
         id: version
         shell: bash
-        run: echo "version=$(poetry version -s)" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "version=$(poetry version -s)" >> "$GITHUB_OUTPUT"
 
       - name: Build wheels
         run: poetry build

--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,8 @@ SERVICE :=
 SEMANTIC_RELEASE = npx --yes \
           -p semantic-release \
           -p conventional-changelog-conventionalcommits \
+          -p conventional-changelog@^8 \
+          -p conventional-changelog-writer@^9 \
           -p "@semantic-release/commit-analyzer" \
           -p "@semantic-release/release-notes-generator" \
           -p "@semantic-release/changelog" \
@@ -72,4 +74,4 @@ release:
 
 .PHONY: release-dry
 release-dry:
-	$(SEMANTIC_RELEASE) --dry-run
+	$(SEMANTIC_RELEASE) --dry-run --no-ci


### PR DESCRIPTION
this PR tries to fix the error:

```
[3:50:32 PM] [semantic-release] › ℹ  Start step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[3:50:32 PM] [semantic-release] › ✘  Failed step "generateNotes" of plugin "@semantic-release/release-notes-generator"
[3:50:32 PM] [semantic-release] › ✘  An error occurred while running semantic-release: Error: Missing helper: "conventional-changelog-conventionalcommits requires conventional-changelog-writer@9 or newer (conventional-changelog@8 or newer). Your changelog tooling loaded an older writer which cannot render this preset. Update the tooling or use an older major version of the preset."
```