### PR TITLE
docs: update all guides with current examples, add transformation/quaity/export/columns pages

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -3,7 +3,7 @@ API Reference
 
 The ``pysus.api`` package provides a layered architecture for discovering,
 downloading, and reading data from Brazilian public health databases
-(DATASUS). It supports three remote data sources.
+(DATASUS). It supports four remote data sources.
 
 Architecture Overview
 ---------------------
@@ -21,7 +21,12 @@ concrete implementations::
     │   └── databases.py     # High-level convenience functions
     ├── ducklake/            # S3 DuckLake catalog client
     ├── ftp/                 # FTP client
-    └── dadosgov/            # dados.gov.br API client
+    ├── dadosgov/            # dados.gov.br API client
+    ├── saude/               # OpenDataSUS catalog client
+    ├── quality/             # Data quality and profiling
+    ├── transform/           # Data transformation
+    ├── export/              # Export to CSV/Excel/GeoJSON/SQL
+    └── diff/                # DataFrame comparison
 
 Quick Start
 -----------
@@ -89,6 +94,145 @@ High-Level Data Functions
    :undoc-members:
    :show-inheritance:
 
+Column Metadata
+---------------
+
+.. automodule:: pysus.api.columns
+   :members:
+   :undoc-members:
+
+.. automodule:: pysus.api.mappings
+   :members:
+   :undoc-members:
+
+Errors & Warnings
+-----------------
+
+.. automodule:: pysus.api.errors
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Cache Management
+----------------
+
+.. automodule:: pysus.api.cache_utils
+   :members:
+   :undoc-members:
+
+Input Validation
+----------------
+
+.. automodule:: pysus.api.validate
+   :members:
+   :undoc-members:
+
+Data Quality
+------------
+
+.. automodule:: pysus.api.quality.statistics
+   :members:
+   :undoc-members:
+
+.. automodule:: pysus.api.quality.missing
+   :members:
+   :undoc-members:
+
+.. automodule:: pysus.api.quality.score
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: pysus.api.quality.validation
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: pysus.api.quality.profiling
+   :members:
+   :undoc-members:
+
+Data Transformation
+-------------------
+
+.. automodule:: pysus.api.transform.aggregation
+   :members:
+   :undoc-members:
+
+.. automodule:: pysus.api.transform.aliases
+   :members:
+   :undoc-members:
+
+.. automodule:: pysus.api.transform.linking
+   :members:
+   :undoc-members:
+
+.. automodule:: pysus.api.transform.masking
+   :members:
+   :undoc-members:
+
+.. automodule:: pysus.api.transform.precision
+   :members:
+   :undoc-members:
+
+.. automodule:: pysus.api.transform.streaming
+   :members:
+   :undoc-members:
+
+.. automodule:: pysus.api.transform.units
+   :members:
+   :undoc-members:
+
+Export
+------
+
+.. automodule:: pysus.api.export
+   :members:
+   :undoc-members:
+
+.. automodule:: pysus.api.export.csv_excel
+   :members:
+   :undoc-members:
+
+.. automodule:: pysus.api.export.geojson
+   :members:
+   :undoc-members:
+
+.. automodule:: pysus.api.export.sql
+   :members:
+   :undoc-members:
+
+Data Diff
+---------
+
+.. automodule:: pysus.api.diff.comparison
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+Metadata Models
+---------------
+
+.. automodule:: pysus.api.metadata.models
+   :members:
+   :undoc-members:
+
+.. automodule:: pysus.api.metadata.report
+   :members:
+   :undoc-members:
+
+OpenDataSUS Client
+------------------
+
+.. automodule:: pysus.api.saude.client
+   :members:
+   :undoc-members:
+   :show-inheritance:
+
+.. automodule:: pysus.api.saude.schemas
+   :members:
+   :undoc-members:
+
 DuckLake Client
 ---------------
 
@@ -151,17 +295,6 @@ Package Root
    :undoc-members:
    :noindex:
 
-Metadata Models
----------------
-
-.. automodule:: pysus.api.metadata.models
-   :members:
-   :undoc-members:
-
-.. automodule:: pysus.api.metadata.report
-   :members:
-   :undoc-members:
-
 DuckLake Internals
 ------------------
 
@@ -196,7 +329,9 @@ Legacy Data Readers
    :members:
    :undoc-members:
 
-.. Comment out CLI docs until saude.py is committed to the repo.
-.. .. automodule:: pysus.cli
-..    :members:
-..    :undoc-members:
+CLI
+---
+
+.. automodule:: pysus.cli
+   :members:
+   :undoc-members:

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -50,6 +50,15 @@ def setup(app):
 
     logging.getLogger("sphinx").addFilter(_InlineLiteralFilter())
 
+    # Dataclasses document fields both as __init__ params and class
+    # attributes.  Suppress the resulting "duplicate object description"
+    # warnings — the output is correct, just double-indexed.
+    class _DuplicateDataclassFilter(logging.Filter):
+        def filter(self, record):
+            return "duplicate object description" not in record.getMessage()
+
+    logging.getLogger("sphinx").addFilter(_DuplicateDataclassFilter())
+
 intersphinx_mapping = {
     "sqlalchemy": ("https://docs.sqlalchemy.org/en/20/", None),
 }

--- a/docs/source/databases/data-sources.rst
+++ b/docs/source/databases/data-sources.rst
@@ -11,7 +11,7 @@ PySUS provides simplified functions that return pandas DataFrames directly:
 
 .. code-block:: python
 
-    from pysus.api import sinan, sinasc, sim, sih, sia, pni, ibge, cnes, ciha
+    from pysus import sinan, sinasc, sim, sih, sia, pni, ibge, cnes, ciha
 
     # Download SINAN Dengue data
     df = sinan(disease="deng", year=2024)
@@ -30,6 +30,22 @@ PySUS provides simplified functions that return pandas DataFrames directly:
 
     # CNES health facilities
     df = cnes(state="SP", year=2024, month=1)
+
+OpenDataSUS (Saude) functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+    from pysus import arboviroses, vacinacao, assistencia_saude
+
+    # Dengue/Chik/Zika notifications
+    df = arboviroses(disease="dengue", year=2024)
+
+    # Vaccination coverage
+    df = vacinacao(state="SP", year=2024)
+
+    # Hospital and health facility data
+    df = assistencia_saude(state="SP", year=2024)
 
 Function Reference
 ^^^^^^^^^^^^^^^^^^
@@ -68,6 +84,43 @@ Function Reference
       - Hospital Admissions
       - state, year, month
 
+OpenDataSUS (Saude) Functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+    :header-rows: 1
+
+    * - Function
+      - Dataset
+      - Parameters
+    * - ``arboviroses(**kwargs)``
+      - Arboviroses (Dengue/Chik/Zika/YF)
+      - disease, state, year (via kwargs)
+    * - ``vacinacao(**kwargs)``
+      - Vaccination Coverage
+      - state, year (via kwargs)
+    * - ``assistencia_saude(**kwargs)``
+      - Hospital/Facility Data
+      - state, year (via kwargs)
+    * - ``atencao_primaria(**kwargs)``
+      - Primary Care (Previne Brasil)
+      - state, year (via kwargs)
+    * - ``sisvan(**kwargs)``
+      - Nutrition Surveillance
+      - state, year (via kwargs)
+    * - ``sisagua(**kwargs)``
+      - Water Quality
+      - state, year (via kwargs)
+    * - ``covid19(**kwargs)``
+      - COVID-19
+      - state, year (via kwargs)
+    * - ``bnafar(**kwargs)``
+      - Pharmaceutical Assistance
+      - state, year (via kwargs)
+    * - ``saude_indigena(**kwargs)``
+      - Indigenous Health
+      - state, year (via kwargs)
+
 Using the PySUS Client
 ^^^^^^^^^^^^^^^^^^^^^^
 
@@ -94,7 +147,7 @@ For more control, use the PySUS client directly:
             # Read parquet files
             import glob
             paths = glob.glob("/cache/**/*.parquet")
-            df = pysus.read_parquet(paths, mode="union").df()
+            df = pysus.read_parquet(paths, mode="union")
 
 read_parquet Modes
 ^^^^^^^^^^^^^^^^^^
@@ -105,12 +158,12 @@ read_parquet Modes
 
 .. code-block:: python
 
-    df = pysus.read_parquet(paths, mode="union").df()
-    df = pysus.read_parquet(paths, mode="intersection").df()
-    df = pysus.read_parquet(paths, mode="strict").df()
+    df = pysus.read_parquet(paths, mode="union")
+    df = pysus.read_parquet(paths, mode="intersection")
+    df = pysus.read_parquet(paths, mode="strict")
 
     # With custom SQL
-    df = pysus.read_parquet(paths, sql="SELECT * WHERE column > 100").df()
+    df = pysus.read_parquet(paths, sql="SELECT * WHERE column > 100")
 
 ---
 

--- a/docs/source/databases/getting_started_pysus.ipynb
+++ b/docs/source/databases/getting_started_pysus.ipynb
@@ -9,7 +9,7 @@
     "\n",
     "*Your complete guide to accessing Brazilian public health data*\n",
     "\n",
-    "**PySUS v3.0.0+ · Python 3.10-3.13**\n",
+    "**PySUS v2.10.1 · Python 3.10-3.13**\n",
     "\n",
     "Notebook contribution — [AlertaDengue/PySUS](https://github.com/AlertaDengue/PySUS)\n",
     "\n",

--- a/docs/source/guides/columns.rst
+++ b/docs/source/guides/columns.rst
@@ -1,0 +1,178 @@
+==========================
+Column Metadata & Schemas
+==========================
+
+PySUS ships curated YAML schemas for SUS datasets, transcribed from
+official data dictionaries. These provide column names, descriptions,
+data types, value codes, and field rules.
+
+Available Schemas
+-----------------
+
+.. code-block:: python
+
+   from pysus import available_databases
+
+   print(available_databases())
+   # ["sim", "sinan"]
+
+Currently available:
+
+- **SIM** — Declaração de Óbito (death certificate)
+- **SINAN** — 30 disease notification schemas (dengue, peste, chikungunya, malaria, tuberculosis, etc.)
+
+SINAN Diseases
+^^^^^^^^^^^^^^
+
+The SINAN schemas cover these diseases:
+
+.. list-table::
+   :header-rows: 1
+
+   * - Disease
+     - Schema File
+   * - Dengue
+     - ``sinan/dengue.yaml``
+   * - Chikungunya
+     - ``sinan/chikungunya.yaml``
+   * - Peste
+     - ``sinan/peste.yaml``
+   * - Malaria
+     - ``sinan/malaria.yaml``
+   * - Tuberculosis
+     - ``sinan/tuberculose.yaml``
+   * - Hanseníase
+     - ``sinan/hanseniase.yaml``
+   * - Hepatites
+     - ``sinan/hepatites.yaml``
+   * - Meningite
+     - ``sinan/meningite.yaml``
+   * - Coqueluche
+     - ``sinan/coqueluche.yaml``
+   * - Raiva
+     - ``sinan/raiva.yaml``
+   * - Febre Amarela
+     - ``sinan/febre_amarela.yaml``
+   * - Chagas
+     - ``sinan/chagas.yaml``
+   * - Leishmaniose Tegumentar
+     - ``sinan/leishmaniose_tegumentar.yaml``
+   * - Leishmaniose Visceral
+     - ``sinan/leishmaniose_visceral.yaml``
+   * - Leptospirose
+     - ``sinan/leptospirose.yaml``
+   * - Esquistossomose
+     - ``sinan/esquistossomose.yaml``
+   * - Hantavirose
+     - ``sinan/hantavirose.yaml``
+   * - Sífilis Congênita
+     - ``sinan/sifilis_congenita.yaml``
+   * - Sífilis Gestacional
+     - ``sinan/sifilis_gestacional.yaml``
+   * - Tetano Neonatal
+     - ``sinan/teti_neonatal.yaml``
+   * - Tetano
+     - ``sinan/teti.yaml``
+   * - Febre Tifoide
+     - ``sinan/febre_tifoide.yaml``
+   * - Febre Maculosa
+     - ``sinan/febre_maculosa.yaml``
+   * - Colera
+     - ``sinan/colera.yaml``
+   * - Difteria
+     - ``sinan/difteria.yaml``
+   * - Botulismo
+     - ``sinan/botulismo.yaml``
+   * - Intoxicação Exógena
+     - ``sinan/intoxicacao_exogena.yaml``
+   * - Acidente por Animais
+     - ``sinan/acidente_por_animais.yaml``
+
+Loading Column Metadata
+-----------------------
+
+.. code-block:: python
+
+   from pysus import load_column_metadata
+
+   # Load columns for a specific SINAN disease
+   columns = load_column_metadata("sinan", "Dengue")
+   for col in columns[:5]:
+       print(f"{col['name']}: {col.get('description_pt', '')}")
+
+   # Load columns for SIM death certificate
+   columns = load_column_metadata("sim", "Declaracao de Obito - DO")
+
+Each column dict contains:
+
+- ``name`` — column name in the data file
+- ``type`` — data type (``string``, ``date``, ``integer``)
+- ``description_pt`` — Portuguese description
+- ``description_en`` — English description (if available)
+- ``required`` — whether the field is mandatory
+- ``categories`` — value code mapping (e.g., ``"1-Sim 2-Não 9-Ignorado"``)
+- ``characteristics`` — field rules and notes from the official dictionary
+- ``format`` — expected format hint (e.g., ``"YYYYMMDD"``)
+
+Searching Columns
+-----------------
+
+Search across all datasets and schemas:
+
+.. code-block:: python
+
+   from pysus import search_columns
+
+   # Find a column by name across all datasets
+   results = search_columns(query="CON_CLASSI")
+   for r in results:
+       print(f"{r.dataset}/{r.endpoint}: {r.name}")
+       if r.categories:
+           print(f"  Categories: {r.categories}")
+
+   # Restrict to a specific dataset
+   results = search_columns(dataset="sinan", query="DT_NOTIFIC")
+
+   # Restrict to a specific disease
+   results = search_columns(dataset="sinan", endpoint="peste")
+
+Returns a list of :class:`~pysus.api.columns.ColumnInfo` dataclasses with
+attributes: ``name``, ``description``, ``description_en``, ``dtype``,
+``dataset``, ``endpoint``, ``categories``, ``characteristics``,
+``required``, ``format``.
+
+Schema Format
+-------------
+
+Each YAML file follows this structure:
+
+.. code-block:: yaml
+
+   dengue:
+     - name: FEBRE
+       type: string
+       description_pt: "Informar qual sinal clínico"
+       type_info: "VARCHAR(1)"
+       required: true
+       categories: "1 – Sim 2 – Não"
+       characteristics: "Campo obrigatório"
+
+     - name: DT_NOTIFIC
+       field: "dt_notificacao"
+       type: date
+       description_pt: "Data da notificação"
+       required: true
+       format: "YYYYMMDD"
+
+Schema fields:
+
+- ``name`` — column name (required)
+- ``type`` — ``string``, ``date``, ``integer`` (required)
+- ``description_pt`` — Portuguese description
+- ``description_en`` — English description
+- ``type_info`` — raw SQL type (e.g., ``VARCHAR(1)``)
+- ``required`` — mandatory on the official form
+- ``categories`` — value code mapping
+- ``characteristics`` — field rules, validation notes
+- ``format`` — expected format hint
+- ``field`` — alternative/alias column name

--- a/docs/source/guides/datasets.rst
+++ b/docs/source/guides/datasets.rst
@@ -109,3 +109,125 @@ hierarchical key::
 Missing attributes use ``_`` (national files use ``BR`` as the state).
 Duplicate logical files are not kept — when the same data arrived from
 multiple origins, only the most updated artifact remains.
+
+Group Codes
+-----------
+
+SINAN Disease Groups
+^^^^^^^^^^^^^^^^^^^^
+
+.. list-table::
+   :header-rows: 1
+
+   * - Group
+     - Disease
+   * - ``DENG``
+     - Dengue
+   * - ``CHIK``
+     - Chikungunya
+   * - ``ZIKA``
+     - Zika
+   * - ``CHAG``
+     - Doença de Chagas
+   * - ``MALA``
+     - Malária
+   * - ``TB``
+     - Tuberculose
+   * - ``HANS``
+     - Hanseníase
+   * - ``HEPA``
+     - Hepatites
+   * - ``MENI``
+     - Meningite
+   * - ``COQ``
+     - Coqueluche
+   * - ``RAIV``
+     - Raiva
+   * - ``FAMA``
+     - Febre Amarela
+   * - ``PEST``
+     - Peste
+   * - ``LEIT``
+     - Leishmaniose Tegumentar
+   * - ``LEIV``
+     - Leishmaniose Visceral
+   * - ``LEPT``
+     - Leptospirose
+   * - ``ESQU``
+     - Esquistossomose
+   * - ``HANT``
+     - Hantavirose
+   * - ``SIFC``
+     - Sífilis Congênita
+   * - ``SIFG``
+     - Sífilis Gestacional
+   * - ``TETN``
+     - Tétano Neonatal
+   * - ``TETA``
+     - Tétano
+   * - ``FT``
+     - Febre Tifoide
+   * - ``FM``
+     - Febre Maculosa
+   * - ``COL``
+     - Cólera
+   * - ``DIF``
+     - Difteria
+   * - ``BOT``
+     - Botulismo
+   * - ``INTOX``
+     - Intoxicação Exógena
+   * - ``ACID``
+     - Acidente por Animais
+
+SIM Groups
+^^^^^^^^^^
+
+- ``DO`` — Declaração de Óbito (death certificate)
+- ``DOR`` — Declaração de Óbito Relacionado ao Aborto
+
+SIA Groups
+^^^^^^^^^^
+
+- ``PA`` — Procedimentos Ambulatoriais
+- ``BI`` — Bolsa Integrada
+- ``AD`` — Administração
+- ``AM`` — Atenção Médica
+- ``AN`` — Análise da Situação de Saúde
+- ``AQ`` — Atenção à Saúde
+- ``AR`` — Assistência Recursal
+
+SIH Groups
+^^^^^^^^^^
+
+- ``RD`` — AIH RDI (produção hospitalar)
+- ``RJ`` — AIH RJ (resumo de internação)
+- ``ER`` — AIH ER (estabelecimentos)
+- ``SP`` — AIH SP (scheda de parto)
+
+CNES Subgroups
+^^^^^^^^^^^^^^
+
+- ``DC`` — Direção/Assistência
+- ``EE`` — Estabelecimento Ensino
+- ``EQ`` — Equipamento
+- ``EP`` — Equipe
+- ``GM`` — Gestão/Mantenedora
+- ``HB`` — Habilitação
+- ``IN`` — Instrumento de Trabalho
+- ``LT`` — Leito
+- ``PF`` — Profissional
+- ``RC`` — Regra de Cobertura
+- ``SR`` — Serviços Especializados
+- ``ST`` — Estabelecimento (Cadastro)
+
+IBGE Groups
+^^^^^^^^^^^
+
+- ``POP`` — População
+- ``ALF`` — Alfabetização
+- ``ESCA`` — Escolaridade A
+- ``ESCB`` — Escolaridade B
+- ``RENDA`` — Renda
+- ``IDOSO`` — Idoso
+- ``PROJ`` — Projeções Populacionais

--- a/docs/source/guides/export.rst
+++ b/docs/source/guides/export.rst
@@ -1,0 +1,97 @@
+======
+Export
+======
+
+PySUS can export DataFrames to CSV, Excel, GeoJSON, SQL, and Parquet,
+with automatic format detection from file extensions.
+
+Auto-Detect Format
+------------------
+
+The ``export`` function picks the writer based on the file extension:
+
+.. code-block:: python
+
+   from pysus import export
+
+   export(df, "output.csv")          # CSV + metadata sidecar
+   export(df, "output.xlsx")         # Excel + metadata sheet
+   export(df, "output.parquet")      # Parquet (native pandas)
+   export(df, "output.json")         # JSON lines
+   export(df, "output.sqlite", table_name="notifications")  # SQLite
+
+CSV
+---
+
+.. code-block:: python
+
+   from pysus import to_csv
+
+   path = to_csv(df, "notifications.csv", encoding="utf-8")
+
+Creates the CSV file plus a ``.metadata.json`` sidecar with row count,
+column types, and any metadata dict passed to the ``metadata`` parameter:
+
+.. code-block:: python
+
+   to_csv(df, "data.csv", metadata={"source": "SINAN", "year": 2024})
+
+Excel
+-----
+
+.. code-block:: python
+
+   from pysus import to_excel
+
+   path = to_excel(df, "report.xlsx", sheet_name="Notifications")
+
+Metadata is included as a separate sheet. Requires ``openpyxl``
+(``pip install pysus[web]`` or ``pip install openpyxl``).
+
+GeoJSON
+-------
+
+Export with geographic coordinates for mapping:
+
+.. code-block:: python
+
+   from pysus import to_geojson
+
+   path = to_geojson(
+       df,
+       "municipalities.geojson",
+       lat_col="LATITUDE",
+       lon_col="LONGITUDE",
+       properties=["ID_AGRAVO", "DT_NOTIFIC", "UF"],
+   )
+
+Creates Point geometries from the lat/lon columns. Optionally include
+a ``geocode_col`` for IBGE municipality codes as properties.
+
+SQL DDL
+-------
+
+Generate a ``CREATE TABLE`` statement from the DataFrame schema:
+
+.. code-block:: python
+
+   from pysus import to_sql
+
+   # Just the schema
+   ddl = to_sql(df, "notifications", dialect="duckdb")
+   print(ddl)
+
+   # With INSERT statements
+   ddl = to_sql(df, "notifications", dialect="duckdb", include_data=True)
+
+Supported dialects: ``"duckdb"``, ``"mysql"``, ``"postgresql"``, ``"sqlite"``.
+
+Compression
+-----------
+
+Pass compression to any writer via ``**kwargs``:
+
+.. code-block:: python
+
+   export(df, "data.csv.gz", compression="gzip")
+   export(df, "data.parquet", compression="snappy")

--- a/docs/source/guides/files-and-formats.rst
+++ b/docs/source/guides/files-and-formats.rst
@@ -1,48 +1,131 @@
-==================
-Files and Formats
-==================
+=================
+Files & Formats
+=================
 
-Every download (any client) returns a local file wrapper from
-:mod:`pysus.api.extensions`, chosen by extension via
-:class:`pysus.api.extensions.ExtensionFactory`.
+PySUS handles the lifecycle of SUS data files: download, decompress,
+convert, and read — transparently across five formats.
 
-Supported formats
+Supported Formats
 -----------------
 
-* ``.dbc`` / ``.dbf`` — legacy DATASUS formats (:class:`DBC`, :class:`DBF`)
-* ``.csv`` — plain text tabular (:class:`CSV`)
-* ``.zip`` — compressed archives (:class:`BaseCompressedFile`)
-* ``.parquet`` — the canonical format (:class:`Parquet`)
+.. list-table::
+   :header-rows: 1
 
-Common interface
+   * - Format
+     - Extension
+     - Notes
+   * - Parquet
+     - ``.parquet``
+     - Preferred. Columnar, compressed, fast. Default download target.
+   * - DBC
+     - ``.dbc``
+     - DBF compressed with blast/SIGL. Auto-decompressed on read.
+   * - DBF
+     - ``.dbf``
+     - dBASE III. Legacy DATASUS format. Read via ``DBFReader``.
+   * - CSV
+     - ``.csv``
+     - Standard comma-separated. Used by OpenDataSUS/Saude.
+   * - ZIP
+     - ``.zip``
+     - Archive container. Auto-extracted to find DBC/DBF/CSV inside.
+
+Common Interface
 ----------------
 
+All file handlers expose a common interface via
+:class:`~pysus.api.extensions.ExtensionFactory`:
+
 .. code-block:: python
 
-   local = await remote_file.download()
+   from pysus.api.extensions import ExtensionFactory
 
-   df = await local.load()              # full DataFrame
-   async for chunk in local.stream():   # chunked iteration
+   # Auto-detect format from extension
+   ext = await ExtensionFactory.instantiate(Path("DENGBR25.parquet"))
+
+   # Full DataFrame
+   df = await ext.load()
+
+   # Chunked streaming
+   async for chunk in ext.stream(chunk_size=50000):
        process(chunk)
 
-   print(local.name, local.extension, local.size, local.modify)
+   # Metadata without loading data
+   print(ext.size, ext.rows, ext.columns)
 
-Tabular files also expose:
+DBC Decompression
+-----------------
 
-.. code-block:: python
-
-   print(local.columns)                 # list of Column(name, description, dtype)
-   print(local.rows)                    # row count
-
-Converting to Parquet
----------------------
-
-Any tabular or compressed file converts with one call:
+DBC files (``.dbc``) are blast-compressed dBASE files. PySUS handles
+decompression automatically:
 
 .. code-block:: python
 
-   parquet = await local.to_parquet()                       # next to the source
-   parquet = await local.to_parquet(output_path="out.parquet")
+   from pysus.api.extensions import ExtensionFactory
 
-The conversion streams in chunks (default 10 000 rows), so large DBC
-files never need to fit in memory at once.
+   ext = await ExtensionFactory.instantiate(Path("SINAN/DENGBR25.dbc"))
+   df = await ext.load()  # decompresses, parses DBF, returns DataFrame
+
+The decompression uses Python's ``blast`` module. For large files
+(>100 MB), consider streaming:
+
+.. code-block:: python
+
+   async for chunk in ext.stream(chunk_size=100000):
+       yield chunk
+
+.. note::
+
+   DBC files with NUL bytes or corrupted headers will raise
+   ``ConversionError``. Re-downloading the file usually resolves this.
+
+DBF Encoding
+------------
+
+DBF files use either ``latin-1`` or ``cp1252`` encoding. PySUS uses
+``latin-1`` by default (since v2.6.3). If you encounter mojibake,
+check the file's origin:
+
+- **DATASUS FTP** → ``latin-1`` (correct default)
+- **Legacy Windows exports** → ``cp1252`` (rare)
+
+Parquet Conversion
+------------------
+
+Downloads are converted to Parquet by default. The conversion is handled
+by :class:`~pysus.api.extensions.ExtensionFactory`:
+
+.. code-block:: python
+
+   from pysus import PySUS
+
+   async with PySUS() as pysus:
+       # download_to_parquet handles DBC→Parquet conversion
+       parquet = await pysus.download_to_parquet(file)
+
+       # Read the converted file
+       df = pysus.read_parquet([parquet.path])
+
+CSV Handling
+------------
+
+OpenDataSUS/Saude resources are distributed as CSV files. These are
+read directly without conversion:
+
+.. code-block:: python
+
+   from pysus import arboviroses
+
+   df = arboviroses(disease="dengue", year=2024)
+
+ZIP Archives
+------------
+
+ZIP files are auto-extracted. The first DBC/DBF/CSV inside is used:
+
+.. code-block:: python
+
+   from pysus.api.extensions import ExtensionFactory
+
+   ext = await ExtensionFactory.instantiate(Path("data.zip"))
+   df = await ext.load()  # extracts and reads the first data file

--- a/docs/source/guides/index.rst
+++ b/docs/source/guides/index.rst
@@ -11,6 +11,10 @@ Guides
    saude
    ducklake
    metadata
+   columns
    files-and-formats
    datasets
+   transform
+   quality
+   export
    web-ui

--- a/docs/source/guides/metadata.rst
+++ b/docs/source/guides/metadata.rst
@@ -75,9 +75,9 @@ Merging across origins
 ----------------------
 
 :func:`~pysus.api.metadata.models.merge_bags` combines bags from
-different origins with a documented per-facet precedence
-(``roadmap_saude.md`` §1.7): Saude wins for descriptive fields,
-DuckLake for structure and content fingerprints, and so on:
+different origins with a documented per-facet precedence: Saude wins
+for descriptive fields, DuckLake for structure and content fingerprints,
+and so on:
 
 .. code-block:: python
 
@@ -104,8 +104,11 @@ any network access:
 Curated column descriptions
 ---------------------------
 
-The Saude catalog can apply curated column descriptions during a sync. The
-SIM Declaração de Óbito resource is covered by
+PySUS ships curated YAML schemas with field names and Portuguese descriptions
+transcribed from official data dictionaries. These cover SIM Declaração de Óbito,
+SINAN disease notifications (dengue, peste, chikungunya, etc.), and other datasets.
+
+The SIM schema is covered by
 ``pysus/api/saude/schemas/vigilanciameioambiente.yaml``. Its field names and
 Portuguese descriptions are transcribed from the official SIM data dictionary
 (portal resource updated 9 June 2025; the file is marked 06/2025); no records
@@ -123,3 +126,21 @@ without relying on a particular data file or downloading a sample:
        "vigilanciameioambiente", "DO24OPEN_csv"
    )
    assert any(column["name"] == "TIPOBITO" for column in columns)
+
+SINAN column metadata includes categories and characteristics
+extracted from the official tarball dictionaries:
+
+.. code-block:: python
+
+   from pysus import search_columns, available_databases, load_column_metadata
+
+   # List available curated schemas
+   print(available_databases())  # ["sim", "sinan"]
+
+   # Load column metadata for a specific SINAN disease
+   columns = load_column_metadata("sinan", "Dengue")
+
+   # Search for a column across all SINAN diseases
+   results = search_columns("CON_CLASSI")
+   for r in results:
+       print(r.dataset, r.name, r.categories)

--- a/docs/source/guides/pysus-orchestrator.rst
+++ b/docs/source/guides/pysus-orchestrator.rst
@@ -3,8 +3,8 @@ The PySUS Orchestrator
 ========================
 
 :class:`pysus.api.client.PySUS` is the central entry point: it manages
-the three clients (S3 catalog, FTP, DadosGov), tracks local downloads,
-converts files to Parquet, and reads them back.
+the four clients (S3 catalog, FTP, DadosGov, OpenDataSUS), tracks local
+downloads, converts files to Parquet, and reads them back.
 
 Connecting
 ----------
@@ -50,6 +50,15 @@ Both return wrappers from :mod:`pysus.api.extensions` that expose
 ``load()`` (full DataFrame), ``stream()`` (chunked) and metadata
 (``size``, ``rows``, ``columns``).
 
+Parallel downloads
+------------------
+
+For batch downloads, use ``download_many`` to fetch files concurrently:
+
+.. code-block:: python
+
+   downloaded = await pysus.download_many(files, max_concurrent=5)
+
 Reading parquet files
 ---------------------
 
@@ -63,6 +72,22 @@ Reading parquet files
 ``read_parquet`` returns a DataFrame when geocode columns are found
 (the IBGE verification digit is applied automatically); otherwise a
 DuckDB connection is returned (use ``.df()`` on it).
+
+Searching for datasets
+----------------------
+
+Use ``search`` for keyword-based discovery across all origins:
+
+.. code-block:: python
+
+   results = await pysus.search("dengue")
+
+Or use the standalone ``list_files`` function:
+
+.. code-block:: python
+
+   from pysus import list_files
+   df = list_files("SINAN", group="DENG", year=2024)
 
 Local download history
 ----------------------

--- a/docs/source/guides/quality.rst
+++ b/docs/source/guides/quality.rst
@@ -1,0 +1,128 @@
+============================
+Data Quality & Profiling
+============================
+
+PySUS provides built-in tools for assessing data quality, profiling
+datasets, and validating against expected schemas.
+
+Column Statistics
+-----------------
+
+Get a per-column summary of types, nulls, uniques, and memory:
+
+.. code-block:: python
+
+   from pysus import column_stats
+
+   stats = column_stats(df)
+   print(stats[["column", "dtype", "null_pct", "unique_count", "memory_mb"]])
+
+Returns a DataFrame with columns: ``column``, ``dtype``, ``null_count``,
+``null_pct``, ``unique_count``, ``unique_pct``, ``memory_bytes``,
+``memory_mb``, ``sample_value``. Sorted by memory usage (descending).
+
+Missing Value Analysis
+----------------------
+
+.. code-block:: python
+
+   from pysus import missing_values
+
+   # Overall missing summary
+   missing = missing_values(df)
+   print(missing[missing["missing_pct"] > 0.1])  # columns with >10% missing
+
+   # Group by state
+   summary, by_state = missing_values(df, group_by="UF")
+
+   # Filter to columns above a threshold
+   high_missing = missing_values(df, threshold=0.3)  # only >30% missing
+
+Quality Score
+-------------
+
+Compute an overall quality score (0-100) with breakdowns:
+
+.. code-block:: python
+
+   from pysus import quality_score
+
+   score = quality_score(df)
+   print(f"Overall: {score.overall:.0f}/100")
+   print(f"  Completeness: {score.completeness:.0f}")
+   print(f"  Validity:     {score.validity:.0f}")
+   print(f"  Consistency:  {score.consistency:.0f}")
+
+Scoring weights:
+
+- **Completeness** (40%): average non-null percentage
+- **Validity** (40%): values passing basic validation checks
+- **Consistency** (20%): values matching expected patterns
+
+Optionally pass a schema for stricter validation:
+
+.. code-block:: python
+
+   from pysus import quality_score, load_column_metadata
+
+   columns = load_column_metadata("sinan", "Dengue")
+   schema = {c["name"]: c for c in columns}
+   score = quality_score(df, schema=schema)
+
+Profile Reports
+---------------
+
+Generate comprehensive profiling reports in text, JSON, or HTML:
+
+.. code-block:: python
+
+   from pysus import profile_report
+
+   # Text report to stdout
+   report = profile_report(df, format="text")
+   print(report)
+
+   # Save as HTML
+   profile_report(df, output="report.html", format="html")
+
+   # Get as dict (for programmatic use)
+   data = profile_report(df, format="json")
+
+Schema Validation
+-----------------
+
+Validate data against expected rules:
+
+.. code-block:: python
+
+   from pysus import validate_data
+
+   results = validate_data(df, dataset="SINAN")
+
+   for r in results:
+       status = "PASS" if r.passed else "FAIL"
+       print(f"  [{status}] {r.column}: {r.rule} — {r.details}")
+
+Built-in validation rules:
+
+- **Age columns** (``IDADE``, ``NU_IDADE_N``): values 0-120
+- **Date columns** (``DT_*``): ``YYYYMMDD`` format, reasonable range
+- **Categorical columns** (``CS_*``): values in expected set
+
+``validate_data`` returns a list of :class:`~pysus.api.quality.validation.ValidationResult`
+objects, including both passing and failing rules.
+
+Dataset Validation
+------------------
+
+Validate a dataset name against known PySUS datasets:
+
+.. code-block:: python
+
+   from pysus import validate_dataset, validate_origin
+
+   canonical = validate_dataset("sinan")  # "SINAN"
+   origin = validate_origin("ftp")        # "FTP"
+
+Both raise :class:`~pysus.api.errors.ValidationError` with suggestions
+for close matches.

--- a/docs/source/guides/saude.rst
+++ b/docs/source/guides/saude.rst
@@ -8,11 +8,6 @@ Brazilian Ministry of Health — `dadosabertos.saude.gov.br
 backend. It exposes the catalog of 138 health datasets, their full CKAN
 metadata, and the resource (file) downloads.
 
-.. note::
-   This is the *catalog* client (Stage 1 of ``roadmap_saude.md``). The
-   structured DEMAS REST API (``apidadosabertos.saude.gov.br``) and the
-   DuckLake sync integration ship in later stages.
-
 No token required
 -----------------
 

--- a/docs/source/guides/transform.rst
+++ b/docs/source/guides/transform.rst
@@ -1,0 +1,169 @@
+====================
+Data Transformation
+====================
+
+PySUS includes tools for aggregating, renaming, linking, masking, and
+optimizing SUS datasets without leaving Python.
+
+Aggregation
+-----------
+
+Aggregate SUS data by state, age group, or time period:
+
+.. code-block:: python
+
+   from pysus import (
+       aggregate_by_state,
+       aggregate_by_age_group,
+       aggregate_by_period,
+   )
+
+   # Count cases by state
+   by_state = aggregate_by_state(df, value_col="ID_AGRAVO", agg_func="count")
+
+   # Sum hospitalizations by age group
+   by_age = aggregate_by_age_group(
+       df,
+       age_col="IDADE",
+       value_col="DIAG_PRINC",
+       bins=[0, 5, 15, 30, 50, 70, 120],
+   )
+
+   # Monthly notifications
+   by_month = aggregate_by_period(
+       df,
+       date_col="DT_NOTIFIC",
+       value_col="ID_AGRAVO",
+       freq="M",       # "M"onthly, "Q"uarterly, "Y"early
+   )
+
+``aggregate_by_period`` expects date columns in ``YYYYMMDD`` format
+(the standard across SINAN, SIM, SINASC, SIH, and SIA).
+
+Column Aliasing and Renaming
+----------------------------
+
+SUS datasets use Portuguese column names that change across form
+editions. ``rename_columns`` and ``get_aliases`` handle this:
+
+.. code-block:: python
+
+   from pysus import rename_columns, get_aliases
+
+   # See what a column was called in previous editions
+   aliases = get_aliases("sinan", "DT_NOTIFIC")
+   # ["DT_NOTIFIC", "DT_NOT_N"]
+
+   # Rename with historical aliases (all old names → canonical)
+   df = rename_columns(df, database="sinan")
+
+   # Or use a custom mapping
+   df = rename_columns(df, mapping={
+       "DT_NOTIFIC": "notification_date",
+       "DT_SIN_PRI": "symptom_onset_date",
+   })
+
+Cross-Dataset Linking
+---------------------
+
+Link two SUS datasets on shared columns (municipality code, CPF, etc.):
+
+.. code-block:: python
+
+   from pysus import get_linking_keys, link_datasets
+
+   # Discover what columns two datasets share
+   keys = get_linking_keys("sinan", "sim")
+   # ["CID_MUNIC", "DT_NOTIFIC", ...]
+
+   # Merge on those keys
+   merged = link_datasets(notifications, deaths, on=keys, how="left")
+
+``link_datasets`` handles column name conflicts by adding ``_left``
+and ``_right`` suffixes.
+
+Sensitive Data Masking
+----------------------
+
+Protect sensitive columns (CPF, names, addresses) before sharing:
+
+.. code-block:: python
+
+   from pysus import mask_data, unmask_data
+
+   # Encrypt sensitive columns (auto-detects CPF/NOME patterns)
+   masked_df, key = mask_data(df, method="encrypt")
+
+   # Or target specific columns
+   masked_df, key = mask_data(
+       df,
+       columns=["CPF", "NOME", "ENDereco"],
+       method="hash",     # "encrypt", "hash", or "redact"
+   )
+
+   # Reverse later with the key
+   original_df = unmask_data(masked_df, columns=["CPF", "NOME"], key=key)
+
+Three masking methods:
+
+- ``"encrypt"`` — reversible AES encryption (default)
+- ``"hash"`` — one-way SHA-256 (irreversible)
+- ``"redact"`` — replace with ``***`` (irreversible, simplest)
+
+Memory Optimization
+-------------------
+
+SUS datasets are large. Optimize memory before analysis:
+
+.. code-block:: python
+
+   from pysus import optimize_memory, set_precision
+
+   # Auto-downcast int/float to smallest sufficient type
+   df = optimize_memory(df)
+
+   # Set specific numeric precision
+   df = set_precision(df, precision="float32")
+
+Typical memory reduction: 30-60% for datasets with mixed int/float columns.
+
+Unit Detection
+--------------
+
+Detect units of measurement in numeric columns:
+
+.. code-block:: python
+
+   from pysus import detect_units
+
+   units = detect_units(df)
+   for u in units:
+       print(f"{u.column}: {u.unit} (confidence: {u.confidence:.0%})")
+
+``detect_units`` uses column names, value ranges, and any available
+metadata to infer units (e.g., ``"kg"``, ``"mg/dL"``, ``"years"``).
+
+Streaming Large Files
+---------------------
+
+For files too large to fit in memory, process them in chunks:
+
+.. code-block:: python
+
+   from pysus import stream_parquet
+
+   for chunk in stream_parquet("large_file.parquet", chunk_size=50000):
+       # Process each chunk
+       results = chunk.groupby("UF").size()
+
+``stream_parquet`` yields DataFrames of ``chunk_size`` rows, reading
+only the specified columns if given:
+
+.. code-block:: python
+
+   for chunk in stream_parquet(
+       "SIHSR2401.parquet",
+       chunk_size=10000,
+       columns=["UF", "IDADE", "DIAG_PRINC"],
+   ):
+       process(chunk)

--- a/docs/source/guides/web-ui.rst
+++ b/docs/source/guides/web-ui.rst
@@ -1,6 +1,6 @@
-=========
-Web UI
-=========
+==============
+Web UI & CLI
+==============
 
 PySUS ships a Streamlit interface (``pysus web``) and a CLI built with
 Typer.
@@ -13,7 +13,7 @@ Launching the web interface
    pysus web            # http://0.0.0.0:8501
    pysus web -p 8080    # custom port
 
-Three tabs map to the three clients:
+Three tabs map to the three data clients:
 
 * **Default (DuckLake)** — the S3 catalog, with group/state/year/month
   filters
@@ -30,9 +30,37 @@ Installing the web extra
 
    pip install pysus[web]
 
-CLI
----
+CLI Reference
+-------------
 
 .. code-block:: bash
 
-   pysus version        # print the installed version
+   pysus version              # print the installed version
+   pysus web                  # launch Streamlit web interface
+   pysus web -p 8080          # custom port
+
+Cache management:
+
+.. code-block:: bash
+
+   pysus cache status         # show cache statistics
+   pysus cache clear          # clear all cached files
+
+Configuration:
+
+.. code-block:: bash
+
+   pysus configure            # interactive configuration wizard
+
+   # or set via environment variables:
+   export PYSUS_CACHEPATH=/data/pysus
+   export DADOSGOV_TOKEN=your-token
+
+Source-specific CLI commands:
+
+.. code-block:: bash
+
+   pysus ducklake list-datasets       # list S3 catalog datasets
+   pysus ducklake search dengue       # search S3 catalog
+   pysus ftp list-datasets            # list FTP datasets
+   pysus dadosgov list-datasets       # list DadosGov datasets

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -20,12 +20,6 @@ For the local web interface:
 
    pip install pysus[web]
 
-For the terminal user interface (TUI):
-
-.. code-block:: bash
-
-   pip install pysus[tui]
-
 Docker
 ------
 

--- a/docs/source/migration.rst
+++ b/docs/source/migration.rst
@@ -2,8 +2,9 @@
 Migrating to 2.x
 =================
 
-PySUS 2.x reworked the API around async clients and a unified file
-hierarchy. This page summarizes what changed for 1.x users.
+PySUS 2.x reworked the API around async clients, a unified file
+hierarchy, and a growing ecosystem of metadata, export, and quality tools.
+This page summarizes what changed for 1.x users.
 
 Async-first clients
 -------------------
@@ -37,8 +38,8 @@ Clients are now asynchronous and share one hierarchy
 Central orchestrator
 --------------------
 
-:class:`pysus.api.client.PySUS` manages all three sources (S3 catalog,
-FTP, DadosGov), tracks downloads and converts to Parquet:
+:class:`pysus.api.client.PySUS` manages all four sources (S3 catalog,
+FTP, DadosGov, OpenDataSUS), tracks downloads and converts to Parquet:
 
 .. code-block:: python
 
@@ -49,6 +50,62 @@ FTP, DadosGov), tracks downloads and converts to Parquet:
 High-level convenience functions (``sinan(...)``, ``sim(...)``, …)
 still exist in 2.x and return Parquet paths or DataFrames
 (``as_dataframe=True``).
+
+OpenDataSUS (Saude) client
+--------------------------
+
+PySUS 2.9+ added a public client for the Ministry of Health's open-data
+portal (``dadosabertos.saude.gov.br``) — no token required:
+
+.. code-block:: python
+
+   from pysus import arboviroses, vacinacao
+
+   df = arboviroses(disease="dengue", year=2024)
+   df = vacinacao(state="SP", year=2024)
+
+Or use the low-level client:
+
+.. code-block:: python
+
+   from pysus.api.saude import SaudeClient
+
+   async with SaudeClient() as client:
+       page = await client.list_datasets(group="arboviroses")
+       for entry in page:
+           print(entry.name, entry.title)
+
+Unified metadata layer
+----------------------
+
+Every remote entity exposes a ``.metadata`` property returning a
+:class:`~pysus.api.metadata.models.MetadataBag` with eight typed facets
+(identity, description, temporal, spatial, provenance, structure,
+access, quality):
+
+.. code-block:: python
+
+   bag = file.metadata
+   print(bag.description.title)
+   print(bag.structure.row_count)
+
+Bags from different origins can be merged:
+
+.. code-block:: python
+
+   from pysus.api.metadata.models import merge_bags
+   merged = merge_bags([ftp_file.metadata, saude_file.metadata])
+
+First-run experience
+--------------------
+
+On first import, PySUS prints a welcome message with the cache path
+and a pointer to ``pysus.info()``:
+
+.. code-block:: python
+
+   import pysus
+   pysus.info()  # prints a table of available datasets
 
 Cache and state
 ---------------
@@ -61,3 +118,120 @@ Cache and state
 Downloads are converted to Parquet by default — the legacy
 ``.dbc``/``.dbf`` formats are parsed through
 :mod:`pysus.api.extensions`.
+
+TOML configuration
+------------------
+
+PySUS reads ``~/.config/pysus/config.toml`` for persistent settings:
+
+.. code-block:: bash
+
+   pysus configure  # interactive wizard
+
+Or set values directly:
+
+.. code-block:: toml
+
+   [download]
+   timeout = 300
+   max_concurrent = 5
+
+   [cache]
+   path = "/data/pysus"
+
+CLI commands
+------------
+
+PySUS ships a CLI built with Typer:
+
+.. code-block:: bash
+
+   pysus version              # installed version
+   pysus web                  # Streamlit web interface
+   pysus web -p 8080          # custom port
+   pysus cache status         # cache statistics
+   pysus cache clear          # clear all cached files
+   pysus configure            # interactive configuration
+
+Friendly errors
+---------------
+
+PySUS raises typed exceptions for common failure modes:
+
+.. code-block:: python
+
+   from pysus import (
+       PySUSError,
+       ConnectionError,
+       DownloadError,
+       ValidationError,
+       FormatError,
+   )
+
+   try:
+       df = sinan(disease="invalid", year=2024)
+   except ValidationError as e:
+       print(e)  # includes hint about valid choices
+
+Progress bars
+-------------
+
+Progress bars are enabled by default. Control them with:
+
+.. code-block:: python
+
+   from pysus import disable_progress_bars, enable_progress_bars
+
+   disable_progress_bars()
+   # ... do work ...
+   enable_progress_bars()
+
+Export
+------
+
+DataFrames can be exported to multiple formats:
+
+.. code-block:: python
+
+   from pysus import to_csv, to_excel, to_geojson, to_sql, export
+
+   to_csv(df, "output.csv")
+   to_excel(df, "output.xlsx")
+   to_geojson(df, "output.geojson", lat_col="LATITUDE", lon_col="LONGITUDE")
+   export(df, "output.csv", compression="gzip")
+
+Data quality
+------------
+
+.. code-block:: python
+
+   from pysus import column_stats, missing_values, quality_score, validate_data
+
+   stats = column_stats(df)
+   missing = missing_values(df)
+   score = quality_score(df)  # 0-100
+   issues = validate_data(df, dataset="SINAN")
+
+Column metadata
+---------------
+
+.. code-block:: python
+
+   from pysus import search_columns, load_column_metadata
+
+   # Search for a column across all datasets
+   results = search_columns("CON_CLASSI")
+   for r in results:
+       print(r.dataset, r.name, r.categories)
+
+   # Load curated columns for a specific dataset
+   columns = load_column_metadata("sinan", "Dengue")
+
+Parallel downloads
+------------------
+
+.. code-block:: python
+
+   async with PySUS() as pysus:
+       files = await pysus.query(dataset="sinan", group="DENG", year=2024)
+       downloaded = await pysus.download_many(files, max_concurrent=5)

--- a/docs/source/quickstart.rst
+++ b/docs/source/quickstart.rst
@@ -11,7 +11,7 @@ Install PySUS::
 Then pick a client — the same file hierarchy
 (:class:`~pysus.api.models.BaseRemoteDataset` →
 :class:`~pysus.api.models.BaseRemoteGroup` →
-:class:`~pysus.api.models.BaseRemoteFile`) is shared by all three
+:class:`~pysus.api.models.BaseRemoteFile`) is shared by all four
 sources:
 
 .. code-block:: python
@@ -89,6 +89,37 @@ DadosGov requires an API token (see :ref:`environment-variables`):
        finally:
            await client.close()
 
+    asyncio.run(main())
+
+OpenDataSUS (Saude)
+-------------------
+
+Public access — no token required. The simplest way to query the Ministry of
+Health's open-data catalog:
+
+.. code-block:: python
+
+   from pysus import arboviroses, vacinacao
+
+   # Dengue notifications from OpenDataSUS
+   df = arboviroses(disease="dengue", year=2024)
+
+   # Vaccination coverage
+   df = vacinacao(state="SP", year=2024)
+
+Or use the Saude client directly:
+
+.. code-block:: python
+
+   import asyncio
+   from pysus.api.saude import SaudeClient
+
+   async def main():
+       async with SaudeClient() as client:
+           page = await client.list_datasets(group="arboviroses")
+           for entry in page:
+               print(entry.name, entry.title)
+
    asyncio.run(main())
 
 Next steps
@@ -98,6 +129,7 @@ Next steps
   read parquet)
 * :doc:`guides/ftp` — FTP client details
 * :doc:`guides/dadosgov` — DadosGov client details
+* :doc:`guides/saude` — OpenDataSUS client details
 * :doc:`guides/ducklake` — S3 catalog details
 * :doc:`guides/files-and-formats` — DBF/DBC/CSV/ZIP/Parquet handling
 * :doc:`guides/web-ui` — the Streamlit interface and CLI

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -4,17 +4,8 @@ Tutorials
 
 Step-by-step usage examples.
 
-.. note::
-
-   Interactive Jupyter notebooks for each client (API overview, DuckLake,
-   FTP and DadosGov) are being added — see the
-   ``docs/ROADMAP.md`` stage 4.
-
-Quick Start
------------
-
 Simplified Database Functions
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------
 
 .. code-block:: python
 
@@ -38,17 +29,46 @@ Simplified Database Functions
    # CNES health facilities
    df = cnes(state="SP", year=2024, month=1)
 
-Listing Available Files
-^^^^^^^^^^^^^^^^^^^^^^^
+OpenDataSUS (Saude) Functions
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. code-block:: python
 
-   from pysus import list_files
+   from pysus import arboviroses, vacinacao, assistencia_saude
 
-   list_files("SINAN")
+   # Dengue/Chik/Zika notifications from OpenDataSUS
+   df = arboviroses(disease="dengue", year=2024)
+
+   # Vaccination coverage
+   df = vacinacao(state="SP", year=2024)
+
+   # Hospital and health facility data
+   df = assistencia_saude(state="SP", year=2024)
+
+   # Primary care (Previne Brasil)
+   df = atencao_primaria(state="SP", year=2024)
+
+   # Nutrition surveillance
+   df = sisvan(state="SP", year=2024)
+
+Discovery
+---------
+
+.. code-block:: python
+
+   from pysus import info_table, search, list_files
+
+   # Browse available datasets
+   info_table()
+
+   # Search for datasets by keyword
+   results = search("dengue")
+
+   # List files in a dataset
+   df = list_files("SINAN", group="DENG", year=2024)
 
 Using the PySUS Client
-^^^^^^^^^^^^^^^^^^^^^^
+----------------------
 
 .. code-block:: python
 
@@ -74,6 +94,14 @@ Using the PySUS Client
            paths = glob.glob("/cache/sinan/**/*.parquet")
            df = pysus.read_parquet(paths, mode="union")
 
+Parallel Downloads
+^^^^^^^^^^^^^^^^^^
+
+.. code-block:: python
+
+   # Download many files in parallel
+   downloaded = await pysus.download_many(files, max_concurrent=5)
+
 read_parquet Modes
 ^^^^^^^^^^^^^^^^^^
 
@@ -90,3 +118,114 @@ read_parquet Modes
 
    # With custom SQL filter
    df = pysus.read_parquet(paths, sql="SELECT * WHERE column > 100")
+
+Data Quality
+------------
+
+.. code-block:: python
+
+   from pysus import column_stats, missing_values, quality_score, validate_data
+
+   # Per-column statistics (types, nulls, uniques, sample values)
+   stats = column_stats(df)
+
+   # Missing value summary
+   missing = missing_values(df)
+
+   # Overall quality score (0-100)
+   score = quality_score(df)
+
+   # Validate data against expected schema
+   issues = validate_data(df, dataset="SINAN")
+
+Data Transformation
+-------------------
+
+.. code-block:: python
+
+   from pysus import (
+       aggregate_by_age_group,
+       aggregate_by_period,
+       aggregate_by_state,
+       detect_units,
+       optimize_memory,
+       rename_columns,
+       to_english,
+   )
+
+   # Aggregate cases by age group
+   grouped = aggregate_by_age_group(df, age_col="IDADE", period_col="DT_NOTIFIC")
+
+   # Detect measurement units in columns
+   units = detect_units(df)
+
+   # Rename columns with a mapping
+   df = rename_columns(df, mapping={"DT_NOTIFIC": "notification_date"})
+
+   # Convert Portuguese column/value names to English
+   df_en = to_english(df)
+
+   # Optimize memory usage
+   df = optimize_memory(df)
+
+Column Metadata
+---------------
+
+.. code-block:: python
+
+   from pysus import search_columns, load_column_metadata, available_databases
+
+   # List curated schema databases
+   print(available_databases())  # ["sim", "sinan"]
+
+   # Load columns for a specific SINAN disease
+   columns = load_column_metadata("sinan", "Dengue")
+
+   # Search for a column across all datasets
+   results = search_columns("CON_CLASSI")
+   for r in results:
+       print(r.dataset, r.name, r.categories)
+
+Export
+------
+
+.. code-block:: python
+
+   from pysus import export, to_csv, to_excel, to_geojson, to_sql
+
+   # Export to various formats
+   to_csv(df, "output.csv")
+   to_excel(df, "output.xlsx")
+   to_geojson(df, "output.geojson", lat_col="LATITUDE", lon_col="LONGITUDE")
+
+   # Full export with options
+   export(df, "output.csv", compression="gzip")
+
+Data Diff
+---------
+
+.. code-block:: python
+
+   from pysus import diff_dfs, diff_summary, diff_rows
+
+   # Compare two DataFrames
+   diff = diff_dfs(df_old, df_new)
+
+   # Summary of differences
+   summary = diff_summary(df_old, df_new)
+
+   # Row-level differences
+   rows = diff_rows(df_old, df_new)
+
+Cache Management
+----------------
+
+.. code-block:: python
+
+   from pysus import cache_status, clear_cache
+
+   # Show cache statistics
+   cache_status()
+
+   # Clear all cached files
+   clear_cache()


### PR DESCRIPTION

- Remove stale TUI reference from installation.rst
- Add Saude (OpenDataSUS) as 4th data source across all pages
- Fix 'three sources' → 'four sources' in quickstart, orchestrator
- Fix 'from pysus.api import' → 'from pysus import' in data-sources.rst
- Fix .df() calls (read_parquet returns DataFrame directly)
- Fix broken roadmap_saude.md reference in metadata.rst
- Fix notebook version 'v3.0.0+' → 'v2.10.1'
- Uncomment CLI automodule in api.rst (saude.py now exists)
- Rewrite tutorials.rst with Saude, quality, transform, export, diff, cache sections
- Expand migration.rst with Saude client, metadata, TOML, CLI, errors, progress bars, export
- Expand files-and-formats.rst with DBC decompression, encoding, streaming details
- Expand datasets.rst with full group code tables (30 SINAN diseases, SIM, SIA, SIH, CNES, IBGE)
- Expand web-ui.rst with full CLI reference
- Add 4 new guide pages: transform.rst, quality.rst, export.rst, columns.rst
- Rewrite api.rst with ~25 missing automodule directives (quality/*, transform/*, export/*, diff/*, columns, mappings, errors, cache_utils, validate, saude/*, cli)
- Add 4 new pages to guides/index.rst toctree