### PR TITLE
Fix async download_many example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,9 @@ with PySUS() as client:
 ```python
 from pysus import download_many
 
-paths = await download_many(files, max_concurrent=5)
+async def download_files(files):
+    paths = await download_many(files, max_concurrent=5)
+    return paths
 ```
 
 ### Streaming / DuckDB


### PR DESCRIPTION
Fix the README example for download_many() by placing the await call inside an async function.

This prevents users from encountering the "'await' outside function" syntax error when following the documentation.